### PR TITLE
extract tracing to separate project and reuse in other projects

### DIFF
--- a/.idea/audiocloud.iml
+++ b/.idea/audiocloud.iml
@@ -15,6 +15,7 @@
       <sourceFolder url="file://$MODULE_DIR$/lib/audiocloud-comms/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/domain/prisma/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/lib/audiocloud-actix-utils/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/lib/audiocloud-tracing/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,7 @@ dependencies = [
  "audiocloud-api",
  "audiocloud-models",
  "audiocloud-rust-clients",
+ "audiocloud-tracing",
  "byteorder",
  "chrono",
  "clap 4.0.18",
@@ -625,7 +626,6 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "trim-margin",
 ]
 
@@ -691,6 +691,28 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "audiocloud-tracing"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 4.0.18",
+ "maplit",
+ "once_cell",
+ "opentelemetry 0.18.0",
+ "opentelemetry-otlp",
+ "opentelemetry-prometheus",
+ "prometheus",
+ "reqwest",
+ "sentry",
+ "sentry-tracing",
+ "tokio",
+ "tracing",
+ "tracing-loki",
+ "tracing-opentelemetry 0.18.0",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/clients/audiocloud-rust-clients/src/domain_server.rs
+++ b/clients/audiocloud-rust-clients/src/domain_server.rs
@@ -7,8 +7,7 @@ use serde::de::DeserializeOwned;
 
 use audiocloud_api::cloud::domains::{EngineConfig, InstanceDriverConfig};
 use audiocloud_api::domain::DomainError;
-
-use audiocloud_api::{EngineId, InstanceDriverId};
+use audiocloud_api::{EngineId, InstanceDriverId, Timestamped};
 
 use crate::create_client;
 
@@ -29,8 +28,8 @@ impl DomainServerClient {
 
     pub async fn register_instance_driver(&self,
                                           driver_id: &InstanceDriverId,
-                                          config: &InstanceDriverConfig)
-                                          -> Result<InstanceDriverConfig> {
+                                          config: &Timestamped<InstanceDriverConfig>)
+                                          -> Result<Timestamped<InstanceDriverConfig>> {
         let url = self.url(format!("/v1/drivers/{driver_id}/register"))?;
 
         let response = self.client.post(url).json(config).send().await.map_err(Self::rpc_err)?;

--- a/domain/audiocloud-domain-server/src/fixed_instances/messages.rs
+++ b/domain/audiocloud-domain-server/src/fixed_instances/messages.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use actix::Message;
 use reqwest::Url;
 
-use audiocloud_api::cloud::domains::InstanceDriverConfig;
+use audiocloud_api::cloud::domains::{InstanceDriverConfig, TimestampedInstanceDriverConfig};
 use audiocloud_api::common::instance::{DesiredInstancePlayState, ReportInstancePlayState, ReportInstancePowerState};
 use audiocloud_api::common::newtypes::FixedInstanceId;
 use audiocloud_api::common::task::{InstanceParameters, InstanceReports};
@@ -69,10 +69,10 @@ pub struct NotifyInstanceError {
 }
 
 #[derive(Message, Clone, Debug)]
-#[rtype(result = "DomainResult<InstanceDriverConfig>")]
+#[rtype(result = "DomainResult<TimestampedInstanceDriverConfig>")]
 pub struct RegisterInstanceDriver {
     pub driver_id: InstanceDriverId,
-    pub provided:  InstanceDriverConfig,
+    pub provided:  TimestampedInstanceDriverConfig,
     pub base_url:  Url,
 }
 

--- a/domain/audiocloud-domain-server/src/fixed_instances/supervisor.rs
+++ b/domain/audiocloud-domain-server/src/fixed_instances/supervisor.rs
@@ -10,7 +10,7 @@ use actix_broker::BrokerSubscribe;
 use reqwest::Url;
 use tracing::*;
 
-use audiocloud_api::cloud::domains::{DomainConfig, FixedInstanceConfig, InstanceDriverConfig};
+use audiocloud_api::cloud::domains::{DomainConfig, FixedInstanceConfig, InstanceDriverConfig, TimestampedInstanceDriverConfig};
 use audiocloud_api::{FixedInstanceId, InstanceDriverId, Timestamped};
 
 use crate::config::NotifyDomainConfiguration;
@@ -34,7 +34,7 @@ pub struct FixedInstancesSupervisor {
 
 #[derive(Clone, Debug)]
 struct SupervisedInstanceDriver {
-    config:    InstanceDriverConfig,
+    config:    TimestampedInstanceDriverConfig,
     instances: HashMap<FixedInstanceId, SupervisedInstance>,
     last_seen: Instant,
     online:    Timestamped<bool>,

--- a/domain/audiocloud-domain-server/src/rest_api/v1/drivers.rs
+++ b/domain/audiocloud-domain-server/src/rest_api/v1/drivers.rs
@@ -9,7 +9,7 @@ use actix_web::{post, web, Error, HttpRequest, Responder};
 use anyhow::anyhow;
 use reqwest::Url;
 
-use audiocloud_api::cloud::domains::InstanceDriverConfig;
+use audiocloud_api::cloud::domains::{InstanceDriverConfig, TimestampedInstanceDriverConfig};
 use audiocloud_api::{InstanceDriverId, ServicePorts};
 
 use crate::fixed_instances::{get_instance_supervisor, FixedInstancesSupervisor, RegisterInstanceDriver};
@@ -21,8 +21,8 @@ pub fn configure(cfg: &mut ServiceConfig) {
 #[post("/{driver_id}/register")]
 async fn register(req: HttpRequest,
                   driver_id: web::Path<InstanceDriverId>,
-                  config: web::Json<InstanceDriverConfig>)
-                  -> Result<web::Json<InstanceDriverConfig>, Error> {
+                  config: web::Json<TimestampedInstanceDriverConfig>)
+                  -> Result<web::Json<TimestampedInstanceDriverConfig>, Error> {
     const PORT: u16 = ServicePorts::InstanceDriverHttps as u16;
 
     let driver_id = driver_id.into_inner();

--- a/domain/audiocloud-driver/Cargo.toml
+++ b/domain/audiocloud-driver/Cargo.toml
@@ -16,7 +16,6 @@ maplit = "1"
 anyhow = "1"
 tracing = "0.1"
 futures = "0.3"
-tracing-subscriber = "0.3"
 byteorder = "1"
 hidapi = "1"
 rand = "0.8"
@@ -62,6 +61,9 @@ path = "../../clients/audiocloud-rust-clients"
 
 [dependencies.audiocloud-actix-utils]
 path = "../../lib/audiocloud-actix-utils"
+
+[dependencies.audiocloud-tracing]
+path = "../../lib/audiocloud-tracing"
 
 [dev-dependencies]
 trim-margin = "0.1.0"

--- a/domain/audiocloud-driver/src/messages.rs
+++ b/domain/audiocloud-driver/src/messages.rs
@@ -4,7 +4,7 @@
 
 use actix::Message;
 
-use audiocloud_api::cloud::domains::InstanceDriverConfig;
+use audiocloud_api::cloud::domains::{InstanceDriverConfig, TimestampedInstanceDriverConfig};
 use audiocloud_api::instance_driver::{
     DesiredInstancePlayStateUpdated, InstanceDriverResult, InstanceParametersUpdated, InstanceWithStatus, InstanceWithStatusList,
 };
@@ -27,7 +27,7 @@ pub struct SetDesiredStateMsg {
 #[derive(Message, Debug, Clone)]
 #[rtype(result = "InstanceDriverResult")]
 pub struct SetInstanceDriverConfigMsg {
-    pub config: InstanceDriverConfig,
+    pub config: TimestampedInstanceDriverConfig,
 }
 
 #[derive(Message, Debug, Clone)]

--- a/lib/audiocloud-tracing/Cargo.toml
+++ b/lib/audiocloud-tracing/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "audiocloud-tracing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tracing = "0.1"
+tracing-loki = "0.2"
+sentry-tracing = "0.27"
+tracing-opentelemetry = "0.18"
+opentelemetry-prometheus = "0.11"
+prometheus = "0.13"
+tokio = "1"
+anyhow = "1"
+reqwest = "0.11"
+maplit = "1"
+once_cell = "1"
+
+[dependencies.clap]
+version = "4"
+features = ["derive", "env"]
+
+[dependencies.tracing-subscriber]
+version = "0.3"
+features = ['env-filter', 'json']
+
+[dependencies.opentelemetry-otlp]
+version = "0.11"
+features = ["metrics", "http-proto", "reqwest-client"]
+
+[dependencies.opentelemetry]
+version = "0.18"
+features = ["rt-tokio"]
+
+[dependencies.sentry]
+version = "0.27"
+features = ["tracing"]

--- a/lib/audiocloud-tracing/src/lib.rs
+++ b/lib/audiocloud-tracing/src/lib.rs
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Audio Cloud, 2022. This code is licensed under MIT license (see LICENSE for details)
+ */
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::env;
+use std::str::FromStr;
+use std::time::Duration;
+
+use clap::{Args, ValueEnum};
+use maplit::hashmap;
+use opentelemetry::Context;
+use reqwest::Url;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer, Registry};
+
+pub use self::otlp::generate_prometheus_metrics;
+
+mod otlp;
+mod sentry;
+
+#[derive(Args, Clone, Debug)]
+pub struct O11yOpts {
+    /// How to export tracing data
+    #[clap(long, env, default_value = "off")]
+    tracing: TracingMode,
+
+    /// How to export metrics data
+    #[clap(long, env, default_value = "off")]
+    metrics: MetricsMode,
+
+    /// The OTLP collector or Grafana agent OTLP endpoint
+    ///
+    /// GRPC and HTTP endpoints should be supported.
+    #[clap(long, env = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", default_value = "grpc://localhost:4317")]
+    otlp_endpoint: String,
+
+    /// Timeout to write metrics and traces to OTLP, in milliseconds
+    #[clap(long, env, default_value = "5000")]
+    otlp_timeout_ms: u64,
+
+    /// Sentry DSN, if tracing is set to 'sentry'
+    ///
+    /// You can get this from the Sentry project settings page, as of time of this writing it is an URL pointing to ingest.sentry.io
+    #[clap(long, env)]
+    sentry_dsn: Option<String>,
+
+    /// Logs can be shipped to a Grafana Loki instance, You can provide a base URL to Loki instance here.
+    ///
+    /// This is used to ship only logs to Loki, and is not used for tracing or metrics.
+    #[clap(long, env)]
+    loki_url: Option<String>,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug)]
+pub enum TracingMode {
+    /// Do not export tracing data (default)
+    Off,
+
+    /// OTLP compatible exporter (GRPC)
+    #[clap(name = "otlp")]
+    OpenTracing,
+
+    /// Sentry compatible exporter
+    Sentry,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug)]
+pub enum MetricsMode {
+    /// Do not export metrics data (default)
+    Off,
+
+    /// Export a /metrics REST endpoint that can be scraped by prometheus compatible metrics scrapers
+    Prometheus,
+
+    /// OTLP compatible exporter (GRPC)
+    #[clap(name = "otlp")]
+    OpenTracing,
+}
+
+pub fn init(opts: &O11yOpts, service_name: &str, instance_name: &str) -> anyhow::Result<Box<dyn Any>> {
+    set_log_env_defaults();
+
+    let filter = || EnvFilter::from_default_env();
+
+    let registry = Registry::default().with(tracing_subscriber::fmt::layer().with_filter(filter()));
+
+    let registry = registry.with(match &opts.loki_url {
+                             None => {
+                                 eprintln!("Loki logs NOT enabled");
+
+                                 None
+                             }
+                             Some(loki_url) => {
+                                 eprintln!("Loki logs shipping to: {}", loki_url);
+                                 let (layer, bg_task) = tracing_loki::layer(Url::from_str(&loki_url)?,
+                                                                            hashmap! {
+                                                                                "service_name".to_owned() => service_name.to_owned(),
+                                                                                "instance_name".to_owned() => instance_name.to_owned(),
+                                                                            },
+                                                                            HashMap::new())?;
+
+                                 tokio::spawn(bg_task);
+
+                                 Some(layer.with_filter(filter()))
+                             }
+                         });
+
+    let mut guard: Box<dyn Any> = Box::new(());
+
+    let registry = registry.with(if let TracingMode::Sentry = opts.tracing {
+                                     let (layer, g) = sentry::sentry_tracing_layer(opts, service_name, instance_name)?;
+                                     guard = g;
+                                     Some(layer)
+                                 } else {
+                                     None
+                                 });
+
+    let registry = registry.with(if let TracingMode::OpenTracing = opts.tracing {
+                                     Some(otlp::otlp_tracing_layer(opts, service_name, instance_name)?)
+                                 } else {
+                                     None
+                                 });
+
+    registry.init();
+
+    Ok(guard)
+}
+
+pub async fn shutdown(guard: Box<dyn Any>) {
+    drop(guard);
+    tokio::time::sleep(Duration::from_secs(2)).await;
+}
+
+pub fn init_metrics(opts: &O11yOpts, service_name: &str, instance_name: &str) -> anyhow::Result<Box<dyn Any>> {
+    match opts.metrics {
+        MetricsMode::Off => {
+            /* metrics exporting is disabled */
+            Ok(Box::new(()))
+        }
+        MetricsMode::OpenTracing => {
+            let metrics = otlp::setup_otlp_metrics(opts, service_name, instance_name)?;
+            Ok(metrics)
+        }
+        MetricsMode::Prometheus => {
+            otlp::setup_prometheus(opts, service_name, instance_name)?;
+            Ok(Box::new(()))
+        }
+    }
+}
+
+fn set_log_env_defaults() {
+    if env::var("RUST_LOG").is_err() {
+        env::set_var("RUST_LOG",
+                     "info,audiocloud_domain_server=debug,audiocloud_cloud_server=debug,audiocloud_instance_driver=debug,audiocloud_api=debug,actix_server=warn,rdkafka=debug");
+    }
+}
+
+pub fn in_context<R>(f: impl FnOnce(&Context) -> R) -> R {
+    let ctx = Context::current();
+    f(&ctx)
+}

--- a/lib/audiocloud-tracing/src/otlp.rs
+++ b/lib/audiocloud-tracing/src/otlp.rs
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Audio Cloud, 2022. This code is licensed under MIT license (see LICENSE for details)
+ */
+
+use std::any::Any;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use once_cell::sync::OnceCell;
+use opentelemetry::sdk::export::metrics::aggregation::cumulative_temporality_selector;
+use opentelemetry::sdk::metrics::{controllers, processors, selectors};
+use opentelemetry::sdk::trace::Tracer;
+use opentelemetry::sdk::{trace, Resource};
+use opentelemetry::{runtime, KeyValue};
+use opentelemetry_otlp::{ExportConfig, WithExportConfig};
+use opentelemetry_prometheus::PrometheusExporter;
+use prometheus::{Encoder, TextEncoder};
+use tracing::Subscriber;
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::registry::LookupSpan;
+
+use crate::O11yOpts;
+
+static PROMETHEUS_EXPORTER: OnceCell<PrometheusExporter> = OnceCell::new();
+
+impl O11yOpts {
+    fn generate_tracing_resource(&self, service_name: &str, instance_name: &str) -> Resource {
+        Resource::new(vec![KeyValue::new("service.name", service_name.to_owned()),
+                           KeyValue::new("service.namespace", "audiocloud.io"),
+                           KeyValue::new("service.instance.name", instance_name.to_owned()),
+                           KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),])
+    }
+}
+
+pub fn otlp_tracing_layer<S>(opts: &O11yOpts, service_name: &str, instance_name: &str) -> anyhow::Result<OpenTelemetryLayer<S, Tracer>>
+    where S: Subscriber + for<'span> LookupSpan<'span>
+{
+    let otlp_exporter = || {
+        opentelemetry_otlp::new_exporter().tonic()
+                                          .with_endpoint(&opts.otlp_endpoint)
+                                          .with_timeout(Duration::from_millis(opts.otlp_timeout_ms))
+    };
+
+    let trace_config = || trace::config().with_resource(opts.generate_tracing_resource(service_name, instance_name));
+
+    let tracer = opentelemetry_otlp::new_pipeline().tracing()
+                                                   .with_exporter(otlp_exporter())
+                                                   .with_trace_config(trace_config())
+                                                   .install_batch(runtime::Tokio)?;
+
+    Ok(tracing_opentelemetry::layer().with_tracer(tracer))
+}
+
+pub fn setup_otlp_metrics(opts: &O11yOpts, service_name: &str, instance_name: &str) -> anyhow::Result<Box<dyn Any>> {
+    let export_config = || ExportConfig { endpoint: opts.otlp_endpoint.to_string(),
+                                          timeout: Duration::from_millis(opts.otlp_timeout_ms),
+                                          ..ExportConfig::default() };
+
+    let metrics =
+        opentelemetry_otlp::new_pipeline().metrics(selectors::simple::inexpensive(), cumulative_temporality_selector(), runtime::Tokio)
+                                          .with_resource(opts.generate_tracing_resource(service_name, instance_name))
+                                          .with_exporter(opentelemetry_otlp::new_exporter().tonic().with_export_config(export_config()))
+                                          .build();
+
+    Ok(Box::new(metrics))
+}
+
+pub fn setup_prometheus(opts: &O11yOpts, service_name: &str, instance_name: &str) -> anyhow::Result<()> {
+    let controller = controllers::basic(
+        processors::factory(
+            selectors::simple::inexpensive(),
+            cumulative_temporality_selector(),
+        )
+        .with_memory(true),
+    )
+    .with_resource(opts.generate_tracing_resource(service_name, instance_name))
+    .build();
+
+    PROMETHEUS_EXPORTER.set(opentelemetry_prometheus::exporter(controller).init())
+                       .map_err(|_| anyhow!("Prometheus exporter already initialized"))?;
+
+    Ok(())
+}
+
+pub fn generate_prometheus_metrics() -> anyhow::Result<String> {
+    let encoder = TextEncoder::new();
+    let metric_families = PROMETHEUS_EXPORTER.get()
+                                             .ok_or_else(|| anyhow!("Prometheus exporter not initialized"))?
+                                             .registry()
+                                             .gather();
+    let mut result = Vec::new();
+    encoder.encode(&metric_families, &mut result)?;
+
+    Ok(String::from_utf8(result)?)
+}

--- a/lib/audiocloud-tracing/src/sentry.rs
+++ b/lib/audiocloud-tracing/src/sentry.rs
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Audio Cloud, 2022. This code is licensed under MIT license (see LICENSE for details)
+ */
+
+use std::any::Any;
+use std::borrow::Cow;
+
+use anyhow::anyhow;
+use sentry_tracing::SentryLayer;
+use tracing::Subscriber;
+use tracing_subscriber::registry::LookupSpan;
+
+use crate::O11yOpts;
+
+pub fn sentry_tracing_layer<S>(opts: &O11yOpts, _service_name: &str, instance_name: &str) -> anyhow::Result<(SentryLayer<S>, Box<dyn Any>)>
+    where S: Subscriber + for<'a> LookupSpan<'a>
+{
+    let dsn = opts.sentry_dsn.as_ref().ok_or_else(|| anyhow!("Sentry DSN not set"))?;
+
+    let guard = sentry::init((dsn.as_str(),
+                              sentry::ClientOptions { // Set this a to lower value in production
+                                                      traces_sample_rate: 1.0,
+                                                      auto_session_tracking: true,
+                                                      server_name: Some(Cow::from(instance_name.to_owned())),
+                                                      ..sentry::ClientOptions::default() }));
+
+    let layer = sentry_tracing::layer();
+
+    Ok((layer, Box::new(guard)))
+}

--- a/specs/audiocloud-api/src/cloud/domains.rs
+++ b/specs/audiocloud-api/src/cloud/domains.rs
@@ -13,7 +13,7 @@ use crate::common::model::{Model, ResourceId};
 use crate::common::task::Task;
 use crate::newtypes::{AppId, AppTaskId, DomainId, FixedInstanceId, ModelId};
 use crate::time::{TimeRange, Timestamp};
-use crate::{EngineId, InstanceDriverId};
+use crate::{EngineId, InstanceDriverId, Timestamped};
 
 /// Used by domain for booting up.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
@@ -23,12 +23,6 @@ pub struct DomainConfig {
     pub domain_id:            DomainId,
     /// Source of model information for the domain (can include unused models)
     pub models:               DomainModelSource,
-    /// Fixed instances configured on the domain
-    #[serde(default)]
-    pub fixed_instances:      HashMap<FixedInstanceId, FixedInstanceConfig>,
-    /// Dynamic instances configured on the domain, with associated limits
-    #[serde(default)]
-    pub dynamic_instances:    HashMap<ModelId, DynamicInstanceLimits>,
     /// Engines configured on the domain
     #[serde(default)]
     pub engines:              HashMap<EngineId, EngineConfig>,
@@ -54,6 +48,8 @@ pub struct DomainConfig {
     #[serde(default)]
     pub event_sink:           DomainEventSink,
 }
+
+pub type TimestampedDomainConfig = Timestamped<DomainConfig>;
 
 fn default_min_task_length() -> i64 {
     5_000
@@ -260,6 +256,8 @@ impl FixedInstanceConfig {
 pub struct InstanceDriverConfig {
     pub instances: HashMap<FixedInstanceId, FixedInstanceConfig>,
 }
+
+pub type TimestampedInstanceDriverConfig = Timestamped<InstanceDriverConfig>;
 
 impl InstanceDriverConfig {
     pub fn merge(&mut self, other: &Self) {

--- a/specs/audiocloud-api/src/domain/mod.rs
+++ b/specs/audiocloud-api/src/domain/mod.rs
@@ -209,6 +209,7 @@ pub fn schemas() -> RootSchema {
                    schema_for!(InstanceDriverId),
                    schema_for!(domains::EngineConfig),
                    schema_for!(domains::InstanceDriverConfig),
+                   schema_for!(domains::TimestampedInstanceDriverConfig),
                    schema_for!(streaming::StreamStats),
                    schema_for!(streaming::DomainServerMessage),
                    schema_for!(streaming::DomainClientMessage),

--- a/specs/openapi/domain_api.yaml
+++ b/specs/openapi/domain_api.yaml
@@ -21,13 +21,13 @@ paths:
       operationId: register_engine
       summary: Register an audio engine
       parameters:
-      - deprecated: false
-        description: The ID of the engine to register
-        in: path
-        name: engine_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/EngineId'
+        - deprecated: false
+          description: The ID of the engine to register
+          in: path
+          name: engine_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/EngineId'
       requestBody:
         content:
           application/json:
@@ -55,7 +55,7 @@ paths:
                 $ref: '#/components/schemas/DomainError'
           description: Not found
       tags:
-      - registration
+        - registration
   /v1/drivers/{driver_id}/register:
     post:
       deprecated: false
@@ -66,26 +66,26 @@ paths:
         and expect to return an updated (merged) configuration that includes any configuration that the domain server knows.
       operationId: register_fixed_instance_driver
       parameters:
-      - deprecated: false
-        description: The manufacturer of the driver
-        in: path
-        name: driver_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/InstanceDriverId'
+        - deprecated: false
+          description: The manufacturer of the driver
+          in: path
+          name: driver_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/InstanceDriverId'
       requestBody:
         content:
           application/json: null
           name: driver_config
           description: The driver configuration
           schema:
-            $ref: '#/components/schemas/InstanceDriverConfig'
+            $ref: '#/components/schemas/TimestampedInstanceDriverConfig'
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InstanceDriverConfig'
+                $ref: '#/components/schemas/TimestampedInstanceDriverConfig'
           description: Success
         '401':
           content:
@@ -100,7 +100,7 @@ paths:
                 $ref: '#/components/schemas/DomainError'
           description: Not found
       tags:
-      - registration
+        - registration
   /v1/streams/{app_id}/{task_id}/{play_id}:
     get:
       deprecated: false
@@ -110,27 +110,27 @@ paths:
         Get statistics about cached packets available in the stream.
       operationId: stream_stats
       parameters:
-      - deprecated: false
-        description: App id
-        in: path
-        name: app_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/AppId'
-      - deprecated: false
-        description: Task id
-        in: path
-        name: task_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/TaskId'
-      - deprecated: false
-        description: Play id
-        in: path
-        name: play_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/PlayId'
+        - deprecated: false
+          description: App id
+          in: path
+          name: app_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppId'
+        - deprecated: false
+          description: Task id
+          in: path
+          name: task_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/TaskId'
+        - deprecated: false
+          description: Play id
+          in: path
+          name: play_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/PlayId'
       responses:
         '200':
           content:
@@ -152,7 +152,7 @@ paths:
           description: Not found
       summary: Get stream statistics
       tags:
-      - streaming
+        - streaming
   /v1/streams/{app_id}/{task_id}/{play_id}/packet/{serial}:
     get:
       deprecated: false
@@ -165,43 +165,43 @@ paths:
         block (wait) for `Timeout` milliseconds before giving up and returning 408.
       operationId: stream_packets
       parameters:
-      - deprecated: false
-        description: App id
-        in: path
-        name: app_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/AppId'
-      - deprecated: false
-        description: Task id
-        in: path
-        name: task_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/TaskId'
-      - deprecated: false
-        description: Play id
-        in: path
-        name: play_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/PlayId'
-      - deprecated: false
-        description: Packet serial number
-        in: path
-        name: serial
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - deprecated: false
-        description: Milliseconds to wait for the packet to be ready
-        in: header
-        name: Timeout
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - deprecated: false
+          description: App id
+          in: path
+          name: app_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppId'
+        - deprecated: false
+          description: Task id
+          in: path
+          name: task_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/TaskId'
+        - deprecated: false
+          description: Play id
+          in: path
+          name: play_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/PlayId'
+        - deprecated: false
+          description: Packet serial number
+          in: path
+          name: serial
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - deprecated: false
+          description: Milliseconds to wait for the packet to be ready
+          in: header
+          name: Timeout
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         '200':
           content:
@@ -229,7 +229,7 @@ paths:
           description: Timed out waiting for packet
       summary: Load packet data
       tags:
-      - streaming
+        - streaming
   /v1/tasks:
     get:
       deprecated: false
@@ -253,7 +253,7 @@ paths:
           description: Not authorized
       summary: List tasks
       tags:
-      - tasks
+        - tasks
     post:
       deprecated: false
       description: |
@@ -296,7 +296,7 @@ paths:
           description: Overlapping task exists
       summary: Create a task
       tags:
-      - tasks
+        - tasks
   /v1/tasks/{app_id}/{task_id}:
     delete:
       deprecated: false
@@ -306,20 +306,20 @@ paths:
         Delete a task and release all referenced resources.
       operationId: delete_task
       parameters:
-      - deprecated: false
-        description: App id
-        in: path
-        name: app_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/AppId'
-      - deprecated: false
-        description: Task id
-        in: path
-        name: task_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/TaskId'
+        - deprecated: false
+          description: App id
+          in: path
+          name: app_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppId'
+        - deprecated: false
+          description: Task id
+          in: path
+          name: task_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/TaskId'
       responses:
         '200':
           content:
@@ -341,7 +341,7 @@ paths:
           description: Not found
       summary: Delete a task
       tags:
-      - tasks
+        - tasks
     get:
       deprecated: false
       description: |
@@ -350,20 +350,20 @@ paths:
         Get details of a task, including dependent media and instance statuses
       operationId: get_task
       parameters:
-      - deprecated: false
-        description: App id
-        in: path
-        name: app_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/AppId'
-      - deprecated: false
-        description: Task id
-        in: path
-        name: task_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/TaskId'
+        - deprecated: false
+          description: App id
+          in: path
+          name: app_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppId'
+        - deprecated: false
+          description: Task id
+          in: path
+          name: task_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/TaskId'
       responses:
         '200':
           content:
@@ -385,7 +385,7 @@ paths:
           description: Not found
       summary: Get task details
       tags:
-      - tasks
+        - tasks
   /v1/tasks/{app_id}/{task_id}/modify:
     post:
       deprecated: false
@@ -396,28 +396,28 @@ paths:
         session: adjusting parameters, creating, deleting, reconnecting nodes, changing media, etc.
       operationId: modify_task
       parameters:
-      - deprecated: false
-        description: App id
-        in: path
-        name: app_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/AppId'
-      - deprecated: false
-        description: Task id
-        in: path
-        name: task_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/TaskId'
-      - deprecated: false
-        description: The task version to be changed
-        in: header
-        name: If-Match
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - deprecated: false
+          description: App id
+          in: path
+          name: app_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppId'
+        - deprecated: false
+          description: Task id
+          in: path
+          name: task_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/TaskId'
+        - deprecated: false
+          description: The task version to be changed
+          in: header
+          name: If-Match
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           application/json:
@@ -451,7 +451,7 @@ paths:
           description: Not allowed to change instances
       summary: Modify existing task
       tags:
-      - tasks
+        - tasks
   /v1/tasks/{app_id}/{task_id}/transport/cancel:
     post:
       deprecated: false
@@ -461,28 +461,28 @@ paths:
         Request to stop (cancel) rendering if the task is rendering.
       operationId: cancel_render_task
       parameters:
-      - deprecated: false
-        description: App id
-        in: path
-        name: app_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/AppId'
-      - deprecated: false
-        description: Task id
-        in: path
-        name: task_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/TaskId'
-      - deprecated: false
-        description: The task version
-        in: header
-        name: If-Match
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - deprecated: false
+          description: App id
+          in: path
+          name: app_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppId'
+        - deprecated: false
+          description: Task id
+          in: path
+          name: task_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/TaskId'
+        - deprecated: false
+          description: The task version
+          in: header
+          name: If-Match
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           application/json:
@@ -510,7 +510,7 @@ paths:
           description: Task or mixer Not found
       summary: Cancel rendering a task
       tags:
-      - tasks
+        - tasks
   /v1/tasks/{app_id}/{task_id}/transport/play:
     post:
       deprecated: false
@@ -521,28 +521,28 @@ paths:
         or with an error.
       operationId: play_task
       parameters:
-      - deprecated: false
-        description: App id
-        in: path
-        name: app_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/AppId'
-      - deprecated: false
-        description: Task id
-        in: path
-        name: task_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/TaskId'
-      - deprecated: false
-        description: The task version
-        in: header
-        name: If-Match
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - deprecated: false
+          description: App id
+          in: path
+          name: app_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppId'
+        - deprecated: false
+          description: Task id
+          in: path
+          name: task_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/TaskId'
+        - deprecated: false
+          description: The task version
+          in: header
+          name: If-Match
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           application/json:
@@ -570,7 +570,7 @@ paths:
           description: Task or mixer Not found
       summary: Start playing a task
       tags:
-      - tasks
+        - tasks
   /v1/tasks/{app_id}/{task_id}/transport/render:
     post:
       deprecated: false
@@ -580,20 +580,20 @@ paths:
         The domain will check that
       operationId: render_task
       parameters:
-      - deprecated: false
-        description: App id
-        in: path
-        name: app_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/AppId'
-      - deprecated: false
-        description: Task id
-        in: path
-        name: task_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/TaskId'
+        - deprecated: false
+          description: App id
+          in: path
+          name: app_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppId'
+        - deprecated: false
+          description: Task id
+          in: path
+          name: task_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/TaskId'
       requestBody:
         content:
           application/json:
@@ -621,7 +621,7 @@ paths:
           description: Task or mixer Not found
       summary: Render a task to a new file
       tags:
-      - tasks
+        - tasks
   /v1/tasks/{app_id}/{task_id}/transport/seek:
     post:
       deprecated: false
@@ -631,20 +631,20 @@ paths:
         If the task is playing, change the playing position.
       operationId: seek_task
       parameters:
-      - deprecated: false
-        description: App id
-        in: path
-        name: app_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/AppId'
-      - deprecated: false
-        description: Task id
-        in: path
-        name: task_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/TaskId'
+        - deprecated: false
+          description: App id
+          in: path
+          name: app_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppId'
+        - deprecated: false
+          description: Task id
+          in: path
+          name: task_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/TaskId'
       requestBody:
         content:
           application/json:
@@ -672,7 +672,7 @@ paths:
           description: Task Not found
       summary: Seek while task is playing
       tags:
-      - tasks
+        - tasks
   /v1/tasks/{app_id}/{task_id}/transport/stop:
     post:
       deprecated: false
@@ -682,28 +682,28 @@ paths:
         Request to stop a track if the task is playing.
       operationId: stop_playing_task
       parameters:
-      - deprecated: false
-        description: App id
-        in: path
-        name: app_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/AppId'
-      - deprecated: false
-        description: Task id
-        in: path
-        name: task_id
-        required: true
-        schema:
-          $ref: '#/components/schemas/TaskId'
-      - deprecated: false
-        description: The task version
-        in: header
-        name: If-Match
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - deprecated: false
+          description: App id
+          in: path
+          name: app_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppId'
+        - deprecated: false
+          description: Task id
+          in: path
+          name: task_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/TaskId'
+        - deprecated: false
+          description: The task version
+          in: header
+          name: If-Match
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           application/json:
@@ -731,12 +731,12 @@ paths:
           description: Task or mixer Not found
       summary: Stop playing a task
       tags:
-      - tasks
+        - tasks
 servers:
-- description: Distopik HQ
-  url: https://distopik-hq.eu.audiocloud.io
-- description: Local development
-  url: http://localhost:7200
+  - description: Distopik HQ
+    url: https://distopik-hq.eu.audiocloud.io
+  - description: Local development
+    url: http://localhost:7200
 components:
   schemas:
     AppId:
@@ -747,31 +747,31 @@ components:
       type: string
     ChannelMask:
       oneOf:
-      - type: object
-        required:
-        - mono
-        properties:
-          mono:
-            type: integer
-            format: uint
-            minimum: 0.0
-        additionalProperties: false
-      - type: object
-        required:
-        - stereo
-        properties:
-          stereo:
-            type: integer
-            format: uint
-            minimum: 0.0
-        additionalProperties: false
+        - type: object
+          required:
+            - mono
+          properties:
+            mono:
+              type: integer
+              format: uint
+              minimum: 0.0
+          additionalProperties: false
+        - type: object
+          required:
+            - stereo
+          properties:
+            stereo:
+              type: integer
+              format: uint
+              minimum: 0.0
+          additionalProperties: false
     ClientId:
       type: string
     ClientSocketId:
       type: object
       required:
-      - client_id
-      - socket_id
+        - client_id
+        - socket_id
       properties:
         client_id:
           $ref: '#/components/schemas/ClientId'
@@ -780,12 +780,12 @@ components:
     CompressedAudio:
       type: object
       required:
-      - buffer
-      - last
-      - num_samples
-      - play_id
-      - stream_pos
-      - timeline_pos
+        - buffer
+        - last
+        - num_samples
+        - play_id
+        - stream_pos
+        - timeline_pos
       properties:
         buffer:
           type: array
@@ -813,28 +813,28 @@ components:
       properties:
         pan:
           type:
-          - number
-          - 'null'
+            - number
+            - 'null'
           format: double
         volume:
           type:
-          - number
-          - 'null'
+            - number
+            - 'null'
           format: double
     CreateTask:
       title: CreateTask
       description: Create a task on the domain
       type: object
       required:
-      - reservations
-      - security
-      - spec
-      - task_id
+        - reservations
+        - security
+        - spec
+        - task_id
       properties:
         reservations:
           description: Task reservations
           allOf:
-          - $ref: '#/components/schemas/CreateTaskReservation'
+            - $ref: '#/components/schemas/CreateTaskReservation'
         security:
           description: Security keys and associateds permissions
           type: object
@@ -843,18 +843,18 @@ components:
         spec:
           description: Task specification
           allOf:
-          - $ref: '#/components/schemas/CreateTaskSpec'
+            - $ref: '#/components/schemas/CreateTaskSpec'
         task_id:
           description: The new app id
           allOf:
-          - $ref: '#/components/schemas/AppTaskId'
+            - $ref: '#/components/schemas/AppTaskId'
     CreateTaskReservation:
       description: Timed resource reservations for the task (must contain all used resources)
       type: object
       required:
-      - fixed_instances
-      - from
-      - to
+        - fixed_instances
+        - from
+        - to
       properties:
         fixed_instances:
           description: Fixed instances reserved for the task
@@ -876,745 +876,745 @@ components:
       properties:
         connections:
           description: Connections between nodes
-          default: {}
+          default: { }
           type: object
           additionalProperties:
             $ref: '#/components/schemas/NodeConnection'
         dynamic:
           description: Dynamic instance nodes of the task
-          default: {}
+          default: { }
           type: object
           additionalProperties:
             $ref: '#/components/schemas/DynamicInstanceNode'
         fixed:
           description: Fixed instance nodes of the task
-          default: {}
+          default: { }
           type: object
           additionalProperties:
             $ref: '#/components/schemas/FixedInstanceNode'
         mixers:
           description: Mixer nodes of the task
-          default: {}
+          default: { }
           type: object
           additionalProperties:
             $ref: '#/components/schemas/MixerNode'
         tracks:
           description: Track nodes of the task
-          default: {}
+          default: { }
           type: object
           additionalProperties:
             $ref: '#/components/schemas/TrackNode'
     DesiredInstancePlayState:
       oneOf:
-      - type: object
-        required:
-        - playing
-        properties:
-          playing:
-            type: object
-            required:
-            - play_id
-            properties:
-              play_id:
-                $ref: '#/components/schemas/PlayId'
-        additionalProperties: false
-      - type: object
-        required:
-        - rendering
-        properties:
-          rendering:
-            type: object
-            required:
-            - length
-            - render_id
-            properties:
-              length:
-                type: number
-                format: double
-              render_id:
-                $ref: '#/components/schemas/RenderId'
-        additionalProperties: false
-      - type: object
-        required:
-        - stopped
-        properties:
-          stopped:
-            type: object
-            properties:
-              position:
-                type:
-                - number
-                - 'null'
-                format: double
-        additionalProperties: false
+        - type: object
+          required:
+            - playing
+          properties:
+            playing:
+              type: object
+              required:
+                - play_id
+              properties:
+                play_id:
+                  $ref: '#/components/schemas/PlayId'
+          additionalProperties: false
+        - type: object
+          required:
+            - rendering
+          properties:
+            rendering:
+              type: object
+              required:
+                - length
+                - render_id
+              properties:
+                length:
+                  type: number
+                  format: double
+                render_id:
+                  $ref: '#/components/schemas/RenderId'
+          additionalProperties: false
+        - type: object
+          required:
+            - stopped
+          properties:
+            stopped:
+              type: object
+              properties:
+                position:
+                  type:
+                    - number
+                    - 'null'
+                  format: double
+          additionalProperties: false
     DesiredInstancePowerState:
       type: string
       enum:
-      - powered_up
-      - shut_down
+        - powered_up
+        - shut_down
     DesiredTaskPlayState:
       description: A desired state for the task play state
       oneOf:
-      - description: Play, with sample rate conversion
-        type: object
-        required:
-        - play
-        properties:
-          play:
-            $ref: '#/components/schemas/RequestPlay'
-        additionalProperties: false
-      - description: Rendering is always a F32 WAV at full sample rate, so nothing else needs to happen here
-        type: object
-        required:
-        - render
-        properties:
-          render:
-            $ref: '#/components/schemas/RequestRender'
-        additionalProperties: false
-      - description: Stopped
-        type: string
-        enum:
-        - stopped
+        - description: Play, with sample rate conversion
+          type: object
+          required:
+            - play
+          properties:
+            play:
+              $ref: '#/components/schemas/RequestPlay'
+          additionalProperties: false
+        - description: Rendering is always a F32 WAV at full sample rate, so nothing else needs to happen here
+          type: object
+          required:
+            - render
+          properties:
+            render:
+              $ref: '#/components/schemas/RequestRender'
+          additionalProperties: false
+        - description: Stopped
+          type: string
+          enum:
+            - stopped
     DiffStamped_for_AnyValue:
       description: Difference stamped in milliseconds since a common epoch, in order to pack most efficiently The epoch in InstancePacket is the created_at field of SessionPacket
       type: array
       items:
-      - type: integer
-        format: uint
-        minimum: 0.0
-      - true
+        - type: integer
+          format: uint
+          minimum: 0.0
+        - true
       maxItems: 2
       minItems: 2
     DiffStamped_for_CompressedAudio:
       description: Difference stamped in milliseconds since a common epoch, in order to pack most efficiently The epoch in InstancePacket is the created_at field of SessionPacket
       type: array
       items:
-      - type: integer
-        format: uint
-        minimum: 0.0
-      - $ref: '#/components/schemas/CompressedAudio'
+        - type: integer
+          format: uint
+          minimum: 0.0
+        - $ref: '#/components/schemas/CompressedAudio'
       maxItems: 2
       minItems: 2
     DiffStamped_for_PadMetering:
       description: Difference stamped in milliseconds since a common epoch, in order to pack most efficiently The epoch in InstancePacket is the created_at field of SessionPacket
       type: array
       items:
-      - type: integer
-        format: uint
-        minimum: 0.0
-      - $ref: '#/components/schemas/PadMetering'
+        - type: integer
+          format: uint
+          minimum: 0.0
+        - $ref: '#/components/schemas/PadMetering'
       maxItems: 2
       minItems: 2
     DomainClientMessage:
       title: DomainClientMessage
       description: A message sent over a real-time communication channel to a streaming domain connection
       oneOf:
-      - description: Request to modify task specification
-        type: object
-        required:
-        - request_modify_task_spec
-        properties:
-          request_modify_task_spec:
-            type: object
-            required:
-            - modify_spec
-            - optional
-            - request_id
-            - revision
-            - task_id
-            properties:
-              modify_spec:
-                description: List of modifications to apply
-                type: array
-                items:
-                  $ref: '#/components/schemas/ModifyTaskSpec'
-              optional:
-                description: If true, the modifications are optional (no error if task already diverged)
-                type: boolean
-              request_id:
-                description: Request id (to reference the response to)
-                allOf:
-                - $ref: '#/components/schemas/RequestId'
-              revision:
-                description: Task version
-                type: integer
-                format: uint64
-                minimum: 0.0
-              task_id:
-                description: Id of the task to modify
-                allOf:
-                - $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
-      - description: Request a new WebRTC peer connection to the domain
-        type: object
-        required:
-        - request_peer_connection
-        properties:
-          request_peer_connection:
-            type: object
-            required:
-            - request_id
-            properties:
-              request_id:
-                description: Request id (to reference the response to)
-                allOf:
-                - $ref: '#/components/schemas/RequestId'
-        additionalProperties: false
-      - type: object
-        required:
-        - answer_peer_connection
-        properties:
-          answer_peer_connection:
-            type: object
-            required:
-            - answer
-            - request_id
-            - socket_id
-            properties:
-              answer:
-                description: The domain server's WebRTC offer response (answer)
-                type: string
-              request_id:
-                description: Request id (to reference the response to)
-                allOf:
-                - $ref: '#/components/schemas/RequestId'
-              socket_id:
-                description: The socket for which we are generating an anwser
-                allOf:
-                - $ref: '#/components/schemas/SocketId'
-        additionalProperties: false
-      - description: Submit a new WebRTC peer connection ICE candidate
-        type: object
-        required:
-        - submit_peer_connection_candidate
-        properties:
-          submit_peer_connection_candidate:
-            type: object
-            required:
-            - request_id
-            - socket_id
-            properties:
-              candidate:
-                description: ICE Candidate
-                type:
-                - string
-                - 'null'
-              request_id:
-                description: Request id (to reference the response to)
-                allOf:
-                - $ref: '#/components/schemas/RequestId'
-              socket_id:
-                description: Socket id of the peer connection
-                allOf:
-                - $ref: '#/components/schemas/SocketId'
-        additionalProperties: false
-      - description: Request attaching to a task
-        type: object
-        required:
-        - request_attach_to_task
-        properties:
-          request_attach_to_task:
-            type: object
-            required:
-            - request_id
-            - secure_key
-            - task_id
-            properties:
-              request_id:
-                description: Request id (to reference the response to)
-                allOf:
-                - $ref: '#/components/schemas/RequestId'
-              secure_key:
-                description: Secure key to use for attachment
-                allOf:
-                - $ref: '#/components/schemas/SecureKey'
-              task_id:
-                description: Id of the task to attach to
-                allOf:
-                - $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
-      - type: object
-        required:
-        - request_detach_from_task
-        properties:
-          request_detach_from_task:
-            type: object
-            required:
-            - request_id
-            - task_id
-            properties:
-              request_id:
-                description: Request id (to reference the response to)
-                allOf:
-                - $ref: '#/components/schemas/RequestId'
-              task_id:
-                description: Id of the task to attach to
-                allOf:
-                - $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
-      - type: object
-        required:
-        - pong
-        properties:
-          pong:
-            type: object
-            required:
-            - challenge
-            - response
-            properties:
-              challenge:
-                type: string
-              response:
-                type: string
-        additionalProperties: false
+        - description: Request to modify task specification
+          type: object
+          required:
+            - request_modify_task_spec
+          properties:
+            request_modify_task_spec:
+              type: object
+              required:
+                - modify_spec
+                - optional
+                - request_id
+                - revision
+                - task_id
+              properties:
+                modify_spec:
+                  description: List of modifications to apply
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ModifyTaskSpec'
+                optional:
+                  description: If true, the modifications are optional (no error if task already diverged)
+                  type: boolean
+                request_id:
+                  description: Request id (to reference the response to)
+                  allOf:
+                    - $ref: '#/components/schemas/RequestId'
+                revision:
+                  description: Task version
+                  type: integer
+                  format: uint64
+                  minimum: 0.0
+                task_id:
+                  description: Id of the task to modify
+                  allOf:
+                    - $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
+        - description: Request a new WebRTC peer connection to the domain
+          type: object
+          required:
+            - request_peer_connection
+          properties:
+            request_peer_connection:
+              type: object
+              required:
+                - request_id
+              properties:
+                request_id:
+                  description: Request id (to reference the response to)
+                  allOf:
+                    - $ref: '#/components/schemas/RequestId'
+          additionalProperties: false
+        - type: object
+          required:
+            - answer_peer_connection
+          properties:
+            answer_peer_connection:
+              type: object
+              required:
+                - answer
+                - request_id
+                - socket_id
+              properties:
+                answer:
+                  description: The domain server's WebRTC offer response (answer)
+                  type: string
+                request_id:
+                  description: Request id (to reference the response to)
+                  allOf:
+                    - $ref: '#/components/schemas/RequestId'
+                socket_id:
+                  description: The socket for which we are generating an anwser
+                  allOf:
+                    - $ref: '#/components/schemas/SocketId'
+          additionalProperties: false
+        - description: Submit a new WebRTC peer connection ICE candidate
+          type: object
+          required:
+            - submit_peer_connection_candidate
+          properties:
+            submit_peer_connection_candidate:
+              type: object
+              required:
+                - request_id
+                - socket_id
+              properties:
+                candidate:
+                  description: ICE Candidate
+                  type:
+                    - string
+                    - 'null'
+                request_id:
+                  description: Request id (to reference the response to)
+                  allOf:
+                    - $ref: '#/components/schemas/RequestId'
+                socket_id:
+                  description: Socket id of the peer connection
+                  allOf:
+                    - $ref: '#/components/schemas/SocketId'
+          additionalProperties: false
+        - description: Request attaching to a task
+          type: object
+          required:
+            - request_attach_to_task
+          properties:
+            request_attach_to_task:
+              type: object
+              required:
+                - request_id
+                - secure_key
+                - task_id
+              properties:
+                request_id:
+                  description: Request id (to reference the response to)
+                  allOf:
+                    - $ref: '#/components/schemas/RequestId'
+                secure_key:
+                  description: Secure key to use for attachment
+                  allOf:
+                    - $ref: '#/components/schemas/SecureKey'
+                task_id:
+                  description: Id of the task to attach to
+                  allOf:
+                    - $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
+        - type: object
+          required:
+            - request_detach_from_task
+          properties:
+            request_detach_from_task:
+              type: object
+              required:
+                - request_id
+                - task_id
+              properties:
+                request_id:
+                  description: Request id (to reference the response to)
+                  allOf:
+                    - $ref: '#/components/schemas/RequestId'
+                task_id:
+                  description: Id of the task to attach to
+                  allOf:
+                    - $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
+        - type: object
+          required:
+            - pong
+          properties:
+            pong:
+              type: object
+              required:
+                - challenge
+                - response
+              properties:
+                challenge:
+                  type: string
+                response:
+                  type: string
+          additionalProperties: false
     DomainCommand:
       title: DomainCommand
       oneOf:
-      - type: object
-        required:
-        - create
-        properties:
-          create:
-            type: object
-            required:
-            - app_session_id
-            - task
-            properties:
-              app_session_id:
-                $ref: '#/components/schemas/AppTaskId'
-              task:
-                $ref: '#/components/schemas/Task'
-        additionalProperties: false
-      - type: object
-        required:
-        - set_spec
-        properties:
-          set_spec:
-            type: object
-            required:
-            - app_session_id
-            - spec
-            - version
-            properties:
-              app_session_id:
-                $ref: '#/components/schemas/AppTaskId'
-              spec:
-                $ref: '#/components/schemas/TaskSpec'
-              version:
-                type: integer
-                format: uint64
-                minimum: 0.0
-        additionalProperties: false
-      - type: object
-        required:
-        - set_security
-        properties:
-          set_security:
-            type: object
-            required:
-            - app_session_id
-            - security
-            - version
-            properties:
-              app_session_id:
-                $ref: '#/components/schemas/AppTaskId'
-              security:
-                type: object
-                additionalProperties:
-                  $ref: '#/components/schemas/TaskPermissions'
-              version:
-                type: integer
-                format: uint64
-                minimum: 0.0
-        additionalProperties: false
-      - type: object
-        required:
-        - modify
-        properties:
-          modify:
-            type: object
-            required:
-            - app_session_id
-            - modifications
-            - version
-            properties:
-              app_session_id:
-                $ref: '#/components/schemas/AppTaskId'
-              modifications:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ModifyTaskSpec'
-              version:
-                type: integer
-                format: uint64
-                minimum: 0.0
-        additionalProperties: false
-      - type: object
-        required:
-        - set_desired_play_state
-        properties:
-          set_desired_play_state:
-            type: object
-            required:
-            - app_session_id
-            - desired_play_state
-            - version
-            properties:
-              app_session_id:
-                $ref: '#/components/schemas/AppTaskId'
-              desired_play_state:
-                $ref: '#/components/schemas/DesiredTaskPlayState'
-              version:
-                type: integer
-                format: uint64
-                minimum: 0.0
-        additionalProperties: false
-      - type: object
-        required:
-        - delete
-        properties:
-          delete:
-            type: object
-            required:
-            - app_session_id
-            properties:
-              app_session_id:
-                $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
+        - type: object
+          required:
+            - create
+          properties:
+            create:
+              type: object
+              required:
+                - app_session_id
+                - task
+              properties:
+                app_session_id:
+                  $ref: '#/components/schemas/AppTaskId'
+                task:
+                  $ref: '#/components/schemas/Task'
+          additionalProperties: false
+        - type: object
+          required:
+            - set_spec
+          properties:
+            set_spec:
+              type: object
+              required:
+                - app_session_id
+                - spec
+                - version
+              properties:
+                app_session_id:
+                  $ref: '#/components/schemas/AppTaskId'
+                spec:
+                  $ref: '#/components/schemas/TaskSpec'
+                version:
+                  type: integer
+                  format: uint64
+                  minimum: 0.0
+          additionalProperties: false
+        - type: object
+          required:
+            - set_security
+          properties:
+            set_security:
+              type: object
+              required:
+                - app_session_id
+                - security
+                - version
+              properties:
+                app_session_id:
+                  $ref: '#/components/schemas/AppTaskId'
+                security:
+                  type: object
+                  additionalProperties:
+                    $ref: '#/components/schemas/TaskPermissions'
+                version:
+                  type: integer
+                  format: uint64
+                  minimum: 0.0
+          additionalProperties: false
+        - type: object
+          required:
+            - modify
+          properties:
+            modify:
+              type: object
+              required:
+                - app_session_id
+                - modifications
+                - version
+              properties:
+                app_session_id:
+                  $ref: '#/components/schemas/AppTaskId'
+                modifications:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ModifyTaskSpec'
+                version:
+                  type: integer
+                  format: uint64
+                  minimum: 0.0
+          additionalProperties: false
+        - type: object
+          required:
+            - set_desired_play_state
+          properties:
+            set_desired_play_state:
+              type: object
+              required:
+                - app_session_id
+                - desired_play_state
+                - version
+              properties:
+                app_session_id:
+                  $ref: '#/components/schemas/AppTaskId'
+                desired_play_state:
+                  $ref: '#/components/schemas/DesiredTaskPlayState'
+                version:
+                  type: integer
+                  format: uint64
+                  minimum: 0.0
+          additionalProperties: false
+        - type: object
+          required:
+            - delete
+          properties:
+            delete:
+              type: object
+              required:
+                - app_session_id
+              properties:
+                app_session_id:
+                  $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
     DomainError:
       oneOf:
-      - type: object
-        required:
-        - error
-        - instance_id
-        - type
-        properties:
-          error:
-            $ref: '#/components/schemas/InstanceDriverError'
-          instance_id:
-            $ref: '#/components/schemas/FixedInstanceId'
-          type:
-            type: string
-            enum:
-            - instance_driver
-      - type: object
-        required:
-        - engine_id
-        - error
-        - type
-        properties:
-          engine_id:
-            $ref: '#/components/schemas/EngineId'
-          error:
-            $ref: '#/components/schemas/EngineError'
-          type:
-            type: string
-            enum:
-            - engine
-      - type: object
-        required:
-        - engine_id
-        - type
-        properties:
-          engine_id:
-            $ref: '#/components/schemas/EngineId'
-          type:
-            type: string
-            enum:
-            - engine_not_found
-      - type: object
-        required:
-        - socket_id
-        - type
-        properties:
-          socket_id:
-            $ref: '#/components/schemas/ClientSocketId'
-          type:
-            type: string
-            enum:
-            - socket_not_found
-      - type: object
-        required:
-        - socket_id
-        - type
-        properties:
-          socket_id:
-            $ref: '#/components/schemas/ClientSocketId'
-          type:
-            type: string
-            enum:
-            - socket_exists
-      - type: object
-        required:
-        - task_id
-        - type
-        properties:
-          task_id:
-            $ref: '#/components/schemas/AppTaskId'
-          type:
-            type: string
-            enum:
-            - task_not_found
-      - type: object
-        required:
-        - play_id
-        - task_id
-        - type
-        properties:
-          play_id:
-            $ref: '#/components/schemas/PlayId'
-          task_id:
-            $ref: '#/components/schemas/AppTaskId'
-          type:
-            type: string
-            enum:
-            - task_stream_not_found
-      - type: object
-        required:
-        - play_id
-        - serial
-        - task_id
-        - type
-        properties:
-          play_id:
-            $ref: '#/components/schemas/PlayId'
-          serial:
-            type: integer
-            format: uint64
-            minimum: 0.0
-          task_id:
-            $ref: '#/components/schemas/AppTaskId'
-          type:
-            type: string
-            enum:
-            - task_packet_not_found
-      - type: object
-        required:
-        - task_id
-        - type
-        properties:
-          task_id:
-            $ref: '#/components/schemas/AppTaskId'
-          type:
-            type: string
-            enum:
-            - task_exists
-      - type: object
-        required:
-        - revision
-        - task_id
-        - type
-        properties:
-          revision:
-            type: integer
-            format: uint64
-            minimum: 0.0
-          task_id:
-            $ref: '#/components/schemas/AppTaskId'
-          type:
-            type: string
-            enum:
-            - task_modification_revision_out_of_date
-      - type: object
-        required:
-        - error
-        - task_id
-        - type
-        properties:
-          error:
-            $ref: '#/components/schemas/ModifyTaskError'
-          task_id:
-            $ref: '#/components/schemas/AppTaskId'
-          type:
-            type: string
-            enum:
-            - task_modification
-      - type: object
-        required:
-        - instance_id
-        - type
-        properties:
-          instance_id:
-            $ref: '#/components/schemas/FixedInstanceId'
-          type:
-            type: string
-            enum:
-            - instance_not_found
-      - type: object
-        required:
-        - instance_id
-        - operation
-        - type
-        properties:
-          instance_id:
-            $ref: '#/components/schemas/FixedInstanceId'
-          operation:
-            type: string
-          type:
-            type: string
-            enum:
-            - instance_not_capable
-      - type: object
-        required:
-        - media_object_id
-        - type
-        properties:
-          media_object_id:
-            $ref: '#/components/schemas/AppMediaObjectId'
-          type:
-            type: string
-            enum:
-            - media_not_found
-      - type: object
-        required:
-        - error
-        - type
-        properties:
-          error:
-            type: string
-          type:
-            type: string
-            enum:
-            - serialization
-      - type: object
-        required:
-        - call
-        - reason
-        - type
-        properties:
-          call:
-            type: string
-          reason:
-            type: string
-          type:
-            type: string
-            enum:
-            - not_implemented
-      - type: object
-        required:
-        - error
-        - type
-        properties:
-          error:
-            type: string
-          type:
-            type: string
-            enum:
-            - bad_gateway
-      - type: object
-        required:
-        - type
-        properties:
-          type:
-            type: string
-            enum:
-            - authentication_failed
-      - type: object
-        required:
-        - error
-        - type
-        properties:
-          error:
-            type: string
-          type:
-            type: string
-            enum:
-            - task_revision_malformed
-      - type: object
-        required:
-        - required
-        - task_id
-        - type
-        properties:
+        - type: object
           required:
-            $ref: '#/components/schemas/TaskPermissions'
-          task_id:
-            $ref: '#/components/schemas/AppTaskId'
-          type:
-            type: string
-            enum:
-            - task_authtorization_failed
-      - type: object
-        required:
-        - state
-        - task_id
-        - type
-        properties:
-          state:
-            $ref: '#/components/schemas/TaskPlayStateSummary'
-          task_id:
-            $ref: '#/components/schemas/AppTaskId'
-          type:
-            type: string
-            enum:
-            - task_illegal_play_state
-      - type: object
-        required:
-        - error
-        - type
-        properties:
-          error:
-            type: string
-          type:
-            type: string
-            enum:
-            - web_r_t_c_error
-      - type: object
-        required:
-        - error
-        - type
-        properties:
-          error:
-            type: string
-          type:
-            type: string
-            enum:
-            - r_p_c
+            - error
+            - instance_id
+            - type
+          properties:
+            error:
+              $ref: '#/components/schemas/InstanceDriverError'
+            instance_id:
+              $ref: '#/components/schemas/FixedInstanceId'
+            type:
+              type: string
+              enum:
+                - instance_driver
+        - type: object
+          required:
+            - engine_id
+            - error
+            - type
+          properties:
+            engine_id:
+              $ref: '#/components/schemas/EngineId'
+            error:
+              $ref: '#/components/schemas/EngineError'
+            type:
+              type: string
+              enum:
+                - engine
+        - type: object
+          required:
+            - engine_id
+            - type
+          properties:
+            engine_id:
+              $ref: '#/components/schemas/EngineId'
+            type:
+              type: string
+              enum:
+                - engine_not_found
+        - type: object
+          required:
+            - socket_id
+            - type
+          properties:
+            socket_id:
+              $ref: '#/components/schemas/ClientSocketId'
+            type:
+              type: string
+              enum:
+                - socket_not_found
+        - type: object
+          required:
+            - socket_id
+            - type
+          properties:
+            socket_id:
+              $ref: '#/components/schemas/ClientSocketId'
+            type:
+              type: string
+              enum:
+                - socket_exists
+        - type: object
+          required:
+            - task_id
+            - type
+          properties:
+            task_id:
+              $ref: '#/components/schemas/AppTaskId'
+            type:
+              type: string
+              enum:
+                - task_not_found
+        - type: object
+          required:
+            - play_id
+            - task_id
+            - type
+          properties:
+            play_id:
+              $ref: '#/components/schemas/PlayId'
+            task_id:
+              $ref: '#/components/schemas/AppTaskId'
+            type:
+              type: string
+              enum:
+                - task_stream_not_found
+        - type: object
+          required:
+            - play_id
+            - serial
+            - task_id
+            - type
+          properties:
+            play_id:
+              $ref: '#/components/schemas/PlayId'
+            serial:
+              type: integer
+              format: uint64
+              minimum: 0.0
+            task_id:
+              $ref: '#/components/schemas/AppTaskId'
+            type:
+              type: string
+              enum:
+                - task_packet_not_found
+        - type: object
+          required:
+            - task_id
+            - type
+          properties:
+            task_id:
+              $ref: '#/components/schemas/AppTaskId'
+            type:
+              type: string
+              enum:
+                - task_exists
+        - type: object
+          required:
+            - revision
+            - task_id
+            - type
+          properties:
+            revision:
+              type: integer
+              format: uint64
+              minimum: 0.0
+            task_id:
+              $ref: '#/components/schemas/AppTaskId'
+            type:
+              type: string
+              enum:
+                - task_modification_revision_out_of_date
+        - type: object
+          required:
+            - error
+            - task_id
+            - type
+          properties:
+            error:
+              $ref: '#/components/schemas/ModifyTaskError'
+            task_id:
+              $ref: '#/components/schemas/AppTaskId'
+            type:
+              type: string
+              enum:
+                - task_modification
+        - type: object
+          required:
+            - instance_id
+            - type
+          properties:
+            instance_id:
+              $ref: '#/components/schemas/FixedInstanceId'
+            type:
+              type: string
+              enum:
+                - instance_not_found
+        - type: object
+          required:
+            - instance_id
+            - operation
+            - type
+          properties:
+            instance_id:
+              $ref: '#/components/schemas/FixedInstanceId'
+            operation:
+              type: string
+            type:
+              type: string
+              enum:
+                - instance_not_capable
+        - type: object
+          required:
+            - media_object_id
+            - type
+          properties:
+            media_object_id:
+              $ref: '#/components/schemas/AppMediaObjectId'
+            type:
+              type: string
+              enum:
+                - media_not_found
+        - type: object
+          required:
+            - error
+            - type
+          properties:
+            error:
+              type: string
+            type:
+              type: string
+              enum:
+                - serialization
+        - type: object
+          required:
+            - call
+            - reason
+            - type
+          properties:
+            call:
+              type: string
+            reason:
+              type: string
+            type:
+              type: string
+              enum:
+                - not_implemented
+        - type: object
+          required:
+            - error
+            - type
+          properties:
+            error:
+              type: string
+            type:
+              type: string
+              enum:
+                - bad_gateway
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - authentication_failed
+        - type: object
+          required:
+            - error
+            - type
+          properties:
+            error:
+              type: string
+            type:
+              type: string
+              enum:
+                - task_revision_malformed
+        - type: object
+          required:
+            - required
+            - task_id
+            - type
+          properties:
+            required:
+              $ref: '#/components/schemas/TaskPermissions'
+            task_id:
+              $ref: '#/components/schemas/AppTaskId'
+            type:
+              type: string
+              enum:
+                - task_authtorization_failed
+        - type: object
+          required:
+            - state
+            - task_id
+            - type
+          properties:
+            state:
+              $ref: '#/components/schemas/TaskPlayStateSummary'
+            task_id:
+              $ref: '#/components/schemas/AppTaskId'
+            type:
+              type: string
+              enum:
+                - task_illegal_play_state
+        - type: object
+          required:
+            - error
+            - type
+          properties:
+            error:
+              type: string
+            type:
+              type: string
+              enum:
+                - web_r_t_c_error
+        - type: object
+          required:
+            - error
+            - type
+          properties:
+            error:
+              type: string
+            type:
+              type: string
+              enum:
+                - r_p_c
     DomainEvent:
       title: DomainEvent
       oneOf:
-      - type: object
-        required:
-        - fixed_instance
-        properties:
-          fixed_instance:
-            type: object
-            required:
-            - event
-            - instance_id
-            properties:
-              event:
-                $ref: '#/components/schemas/InstanceEvent'
-              instance_id:
-                $ref: '#/components/schemas/FixedInstanceId'
-        additionalProperties: false
-      - type: object
-        required:
-        - task
-        properties:
-          task:
-            type: object
-            required:
-            - event
-            - task_id
-            properties:
-              event:
-                $ref: '#/components/schemas/TaskEvent'
-              task_id:
-                $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
+        - type: object
+          required:
+            - fixed_instance
+          properties:
+            fixed_instance:
+              type: object
+              required:
+                - event
+                - instance_id
+              properties:
+                event:
+                  $ref: '#/components/schemas/InstanceEvent'
+                instance_id:
+                  $ref: '#/components/schemas/FixedInstanceId'
+          additionalProperties: false
+        - type: object
+          required:
+            - task
+          properties:
+            task:
+              type: object
+              required:
+                - event
+                - task_id
+              properties:
+                event:
+                  $ref: '#/components/schemas/TaskEvent'
+                task_id:
+                  $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
     DomainFixedInstanceEngine:
       description: Configuration of how a fixed instance is connected to the domain
       type: object
       required:
-      - engine_id
-      - input_start
-      - output_start
+        - engine_id
+        - input_start
+        - output_start
       properties:
         engine_id:
           description: Engine hosting the instance, if any
           allOf:
-          - $ref: '#/components/schemas/EngineId'
+            - $ref: '#/components/schemas/EngineId'
         input_start:
           description: Instance inputs start at index on engine
           type: integer
@@ -1631,8 +1631,8 @@ components:
       description: Instance media settings
       type: object
       required:
-      - length_ms
-      - renders_rewind_to_start
+        - length_ms
+        - renders_rewind_to_start
       properties:
         length_ms:
           description: Lenght of the inserted media in milliseconds
@@ -1645,8 +1645,8 @@ components:
 
             - If null, rewind to start - Otherwise, rewind by specified amount of milliseconds
           type:
-          - integer
-          - 'null'
+            - integer
+            - 'null'
           format: uint
           minimum: 0.0
         renders_rewind_to_start:
@@ -1656,8 +1656,8 @@ components:
       description: Instance power settings
       type: object
       required:
-      - channel
-      - instance
+        - channel
+        - instance
       properties:
         channel:
           description: Which channel on the power instance is distributing power to this instance
@@ -1679,7 +1679,7 @@ components:
         instance:
           description: Power instance used to distribute power to this instance
           allOf:
-          - $ref: '#/components/schemas/FixedInstanceId'
+            - $ref: '#/components/schemas/FixedInstanceId'
         warm_up_ms:
           description: Number of milliseconds to wait to warm up after powering on
           default: 2500
@@ -1690,223 +1690,223 @@ components:
       title: DomainServerMessage
       description: A mesasge received over a real-time communication channel from a streaming domain connection
       oneOf:
-      - description: Task generated event
-        type: object
-        required:
-        - task_event
-        properties:
-          task_event:
-            type: object
-            required:
-            - event
-            - task_id
-            properties:
-              event:
-                description: Event details
-                allOf:
-                - $ref: '#/components/schemas/TaskEvent'
-              task_id:
-                description: Id of the task generating the event
-                allOf:
-                - $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
-      - description: Response to a request to change a task play state
-        type: object
-        required:
-        - set_desired_play_state_response
-        properties:
-          set_desired_play_state_response:
-            type: object
-            required:
-            - request_id
-            - result
-            properties:
-              request_id:
-                description: Request id this message is responding to
-                allOf:
-                - $ref: '#/components/schemas/RequestId'
-              result:
-                description: Result
-                allOf:
-                - $ref: '#/components/schemas/SerializableResult_for_TaskUpdated_and_DomainError'
-        additionalProperties: false
-      - description: Response to a request to change task specification
-        type: object
-        required:
-        - modify_task_spec_response
-        properties:
-          modify_task_spec_response:
-            type: object
-            required:
-            - request_id
-            - result
-            properties:
-              request_id:
-                description: Request id this message is responding to
-                allOf:
-                - $ref: '#/components/schemas/RequestId'
-              result:
-                description: Result of the operation
-                allOf:
-                - $ref: '#/components/schemas/SerializableResult_for_TaskUpdated_and_DomainError'
-        additionalProperties: false
-      - description: Response to initiating a new peer connection
-        type: object
-        required:
-        - peer_connection_response
-        properties:
-          peer_connection_response:
-            type: object
-            required:
-            - request_id
-            - result
-            properties:
-              request_id:
-                description: Request id this message is responding to
-                allOf:
-                - $ref: '#/components/schemas/RequestId'
-              result:
-                description: Result of the operation - the assigned socket ID
-                allOf:
-                - $ref: '#/components/schemas/SerializableResult_for_PeerConnectionCreated_and_DomainError'
-        additionalProperties: false
-      - type: object
-        required:
-        - answer_peer_connection_response
-        properties:
-          answer_peer_connection_response:
-            type: object
-            required:
-            - request_id
-            - result
-            properties:
-              request_id:
-                description: Request id this message is responding to
-                allOf:
-                - $ref: '#/components/schemas/RequestId'
-              result:
-                description: Result of the operation or error
-                allOf:
-                - $ref: '#/components/schemas/SerializableResult_for_Null_and_DomainError'
-        additionalProperties: false
-      - description: Response to submitting a peer connection candidate
-        type: object
-        required:
-        - peer_connection_candidate_response
-        properties:
-          peer_connection_candidate_response:
-            type: object
-            required:
-            - request_id
-            - result
-            properties:
-              request_id:
-                description: Request id this message is responding to
-                allOf:
-                - $ref: '#/components/schemas/RequestId'
-              result:
-                description: Result of the operation
-                allOf:
-                - $ref: '#/components/schemas/SerializableResult_for_Null_and_DomainError'
-        additionalProperties: false
-      - description: Response to a request to attach the socket to a task
-        type: object
-        required:
-        - attach_to_task_response
-        properties:
-          attach_to_task_response:
-            type: object
-            required:
-            - request_id
-            - result
-            properties:
-              request_id:
-                description: Request id this message is responding to
-                allOf:
-                - $ref: '#/components/schemas/RequestId'
-              result:
-                description: Result of the operation
-                allOf:
-                - $ref: '#/components/schemas/SerializableResult_for_Null_and_DomainError'
-        additionalProperties: false
-      - description: Response to detach the socket from a task
-        type: object
-        required:
-        - detach_from_task_response
-        properties:
-          detach_from_task_response:
-            type: object
-            required:
-            - request_id
-            - result
-            properties:
-              request_id:
-                description: Request id this message is responding to
-                allOf:
-                - $ref: '#/components/schemas/RequestId'
-              result:
-                description: Result of the operation - will be success even if task does not exist
-                allOf:
-                - $ref: '#/components/schemas/SerializableResult_for_Null_and_DomainError'
-        additionalProperties: false
-      - description: Submit a new WebRTC peer connection ICE candidate
-        type: object
-        required:
-        - submit_peer_connection_candidate
-        properties:
-          submit_peer_connection_candidate:
-            type: object
-            required:
-            - socket_id
-            properties:
-              candidate:
-                description: ICE Candidate
-                type:
-                - string
-                - 'null'
-              socket_id:
-                description: Socket id of the peer connection
-                allOf:
-                - $ref: '#/components/schemas/SocketId'
-        additionalProperties: false
-      - description: Ping message
-        type: object
-        required:
-        - ping
-        properties:
-          ping:
-            type: object
-            required:
-            - challenge
-            properties:
-              challenge:
-                description: |-
-                  Challenge string
-
-                  In a future release, this field will contain a challenge that must be processed and returned to validate that the client is running a valid version of the client code
-                type: string
-        additionalProperties: false
-      - description: Notify the task permissions on this socket
-        type: object
-        required:
-        - notify_task_permissions
-        properties:
-          notify_task_permissions:
-            type: object
-            required:
-            - permissions
-            properties:
-              permissions:
-                description: Mapping from each available task to permission information to that task
-                type: object
-                additionalProperties:
-                  $ref: '#/components/schemas/TaskPermissions'
-        additionalProperties: false
+        - description: Task generated event
+          type: object
+          required:
+            - task_event
+          properties:
+            task_event:
+              type: object
+              required:
+                - event
+                - task_id
+              properties:
+                event:
+                  description: Event details
+                  allOf:
+                    - $ref: '#/components/schemas/TaskEvent'
+                task_id:
+                  description: Id of the task generating the event
+                  allOf:
+                    - $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
+        - description: Response to a request to change a task play state
+          type: object
+          required:
+            - set_desired_play_state_response
+          properties:
+            set_desired_play_state_response:
+              type: object
+              required:
+                - request_id
+                - result
+              properties:
+                request_id:
+                  description: Request id this message is responding to
+                  allOf:
+                    - $ref: '#/components/schemas/RequestId'
+                result:
+                  description: Result
+                  allOf:
+                    - $ref: '#/components/schemas/SerializableResult_for_TaskUpdated_and_DomainError'
+          additionalProperties: false
+        - description: Response to a request to change task specification
+          type: object
+          required:
+            - modify_task_spec_response
+          properties:
+            modify_task_spec_response:
+              type: object
+              required:
+                - request_id
+                - result
+              properties:
+                request_id:
+                  description: Request id this message is responding to
+                  allOf:
+                    - $ref: '#/components/schemas/RequestId'
+                result:
+                  description: Result of the operation
+                  allOf:
+                    - $ref: '#/components/schemas/SerializableResult_for_TaskUpdated_and_DomainError'
+          additionalProperties: false
+        - description: Response to initiating a new peer connection
+          type: object
+          required:
+            - peer_connection_response
+          properties:
+            peer_connection_response:
+              type: object
+              required:
+                - request_id
+                - result
+              properties:
+                request_id:
+                  description: Request id this message is responding to
+                  allOf:
+                    - $ref: '#/components/schemas/RequestId'
+                result:
+                  description: Result of the operation - the assigned socket ID
+                  allOf:
+                    - $ref: '#/components/schemas/SerializableResult_for_PeerConnectionCreated_and_DomainError'
+          additionalProperties: false
+        - type: object
+          required:
+            - answer_peer_connection_response
+          properties:
+            answer_peer_connection_response:
+              type: object
+              required:
+                - request_id
+                - result
+              properties:
+                request_id:
+                  description: Request id this message is responding to
+                  allOf:
+                    - $ref: '#/components/schemas/RequestId'
+                result:
+                  description: Result of the operation or error
+                  allOf:
+                    - $ref: '#/components/schemas/SerializableResult_for_Null_and_DomainError'
+          additionalProperties: false
+        - description: Response to submitting a peer connection candidate
+          type: object
+          required:
+            - peer_connection_candidate_response
+          properties:
+            peer_connection_candidate_response:
+              type: object
+              required:
+                - request_id
+                - result
+              properties:
+                request_id:
+                  description: Request id this message is responding to
+                  allOf:
+                    - $ref: '#/components/schemas/RequestId'
+                result:
+                  description: Result of the operation
+                  allOf:
+                    - $ref: '#/components/schemas/SerializableResult_for_Null_and_DomainError'
+          additionalProperties: false
+        - description: Response to a request to attach the socket to a task
+          type: object
+          required:
+            - attach_to_task_response
+          properties:
+            attach_to_task_response:
+              type: object
+              required:
+                - request_id
+                - result
+              properties:
+                request_id:
+                  description: Request id this message is responding to
+                  allOf:
+                    - $ref: '#/components/schemas/RequestId'
+                result:
+                  description: Result of the operation
+                  allOf:
+                    - $ref: '#/components/schemas/SerializableResult_for_Null_and_DomainError'
+          additionalProperties: false
+        - description: Response to detach the socket from a task
+          type: object
+          required:
+            - detach_from_task_response
+          properties:
+            detach_from_task_response:
+              type: object
+              required:
+                - request_id
+                - result
+              properties:
+                request_id:
+                  description: Request id this message is responding to
+                  allOf:
+                    - $ref: '#/components/schemas/RequestId'
+                result:
+                  description: Result of the operation - will be success even if task does not exist
+                  allOf:
+                    - $ref: '#/components/schemas/SerializableResult_for_Null_and_DomainError'
+          additionalProperties: false
+        - description: Submit a new WebRTC peer connection ICE candidate
+          type: object
+          required:
+            - submit_peer_connection_candidate
+          properties:
+            submit_peer_connection_candidate:
+              type: object
+              required:
+                - socket_id
+              properties:
+                candidate:
+                  description: ICE Candidate
+                  type:
+                    - string
+                    - 'null'
+                socket_id:
+                  description: Socket id of the peer connection
+                  allOf:
+                    - $ref: '#/components/schemas/SocketId'
+          additionalProperties: false
+        - description: Ping message
+          type: object
+          required:
+            - ping
+          properties:
+            ping:
+              type: object
+              required:
+                - challenge
+              properties:
+                challenge:
+                  description: |-
+                    Challenge string
+                    
+                    In a future release, this field will contain a challenge that must be processed and returned to validate that the client is running a valid version of the client code
+                  type: string
+          additionalProperties: false
+        - description: Notify the task permissions on this socket
+          type: object
+          required:
+            - notify_task_permissions
+          properties:
+            notify_task_permissions:
+              type: object
+              required:
+                - permissions
+              properties:
+                permissions:
+                  description: Mapping from each available task to permission information to that task
+                  type: object
+                  additionalProperties:
+                    $ref: '#/components/schemas/TaskPermissions'
+          additionalProperties: false
     DynamicInstanceLimits:
       description: Limits on dynamic instances
       type: object
       required:
-      - max_instances
+        - max_instances
       properties:
         max_instances:
           description: |-
@@ -1920,13 +1920,13 @@ components:
       description: Dynamic node specification
       type: object
       required:
-      - model_id
-      - parameters
+        - model_id
+        - parameters
       properties:
         model_id:
           description: The manufacturer and name of the processing software
           allOf:
-          - $ref: '#/components/schemas/ModelId'
+            - $ref: '#/components/schemas/ModelId'
         parameters:
           description: Parameter values
     DynamicInstanceNodeId:
@@ -1936,15 +1936,15 @@ components:
       description: Information about a media engine within a domain
       type: object
       required:
-      - max_concurrent_tasks
-      - sample_rate
+        - max_concurrent_tasks
+        - sample_rate
       properties:
         additional:
           description: Additional configuration, specific to the engine configuration
           default: null
         dynamic_instances:
           description: Dynamic instances configured on the audio engine, with associated limits
-          default: {}
+          default: { }
           type: object
           additionalProperties:
             $ref: '#/components/schemas/DynamicInstanceLimits'
@@ -1955,7 +1955,7 @@ components:
           minimum: 0.0
         resources:
           description: Resources available on the domain
-          default: {}
+          default: { }
           type: object
           additionalProperties:
             type: number
@@ -1967,73 +1967,73 @@ components:
           minimum: 0.0
     EngineError:
       oneOf:
-      - type: object
-        required:
-        - track
-        - type
-        properties:
-          track:
-            type: integer
-            format: uint
-            minimum: 0.0
-          type:
-            type: string
-            enum:
-            - track_not_found
-      - type: object
-        required:
-        - item
-        - track
-        - type
-        properties:
-          item:
-            type: integer
-            format: uint
-            minimum: 0.0
-          track:
-            type: integer
-            format: uint
-            minimum: 0.0
-          type:
-            type: string
-            enum:
-            - item_not_found
-      - type: object
-        required:
-        - error
-        - task
-        - type
-        properties:
-          error:
-            $ref: '#/components/schemas/ModifyTaskError'
-          task:
-            $ref: '#/components/schemas/AppTaskId'
-          type:
-            type: string
-            enum:
-            - modify_task
-      - type: object
-        required:
-        - error
-        - type
-        properties:
-          error:
-            type: string
-          type:
-            type: string
-            enum:
-            - internal_error
-      - type: object
-        required:
-        - error
-        - type
-        properties:
-          error:
-            type: string
-          type:
-            type: string
-            enum:
-            - r_p_c
+        - type: object
+          required:
+            - track
+            - type
+          properties:
+            track:
+              type: integer
+              format: uint
+              minimum: 0.0
+            type:
+              type: string
+              enum:
+                - track_not_found
+        - type: object
+          required:
+            - item
+            - track
+            - type
+          properties:
+            item:
+              type: integer
+              format: uint
+              minimum: 0.0
+            track:
+              type: integer
+              format: uint
+              minimum: 0.0
+            type:
+              type: string
+              enum:
+                - item_not_found
+        - type: object
+          required:
+            - error
+            - task
+            - type
+          properties:
+            error:
+              $ref: '#/components/schemas/ModifyTaskError'
+            task:
+              $ref: '#/components/schemas/AppTaskId'
+            type:
+              type: string
+              enum:
+                - modify_task
+        - type: object
+          required:
+            - error
+            - type
+          properties:
+            error:
+              type: string
+            type:
+              type: string
+              enum:
+                - internal_error
+        - type: object
+          required:
+            - error
+            - type
+          properties:
+            error:
+              type: string
+            type:
+              type: string
+              enum:
+                - r_p_c
     EngineId:
       type: string
     FixedInstanceConfig:
@@ -2047,8 +2047,8 @@ components:
           description: Apps allowed to access the instance or null if the domain defaults are used
           default: null
           type:
-          - array
-          - 'null'
+            - array
+            - 'null'
           items:
             $ref: '#/components/schemas/AppId'
           uniqueItems: true
@@ -2056,17 +2056,17 @@ components:
           description: Which driver is using
           default: null
           anyOf:
-          - $ref: '#/components/schemas/InstanceDriverId'
-          - type: 'null'
+            - $ref: '#/components/schemas/InstanceDriverId'
+            - type: 'null'
         engine:
           description: Configuration of how a fixed instance is connected to the domain
           default: null
           anyOf:
-          - $ref: '#/components/schemas/DomainFixedInstanceEngine'
-          - type: 'null'
+            - $ref: '#/components/schemas/DomainFixedInstanceEngine'
+            - type: 'null'
         maintenance:
           description: Maintenance windows on this instance
-          default: []
+          default: [ ]
           type: array
           items:
             $ref: '#/components/schemas/Maintenance'
@@ -2074,17 +2074,17 @@ components:
           description: Optional configuration if instance handles media (such as tape machines)
           default: null
           anyOf:
-          - $ref: '#/components/schemas/DomainMediaInstanceConfig'
-          - type: 'null'
+            - $ref: '#/components/schemas/DomainMediaInstanceConfig'
+            - type: 'null'
         power:
           description: Optional configuration to powers on/off instance to conserve energy
           default: null
           anyOf:
-          - $ref: '#/components/schemas/DomainPowerInstanceConfig'
-          - type: 'null'
+            - $ref: '#/components/schemas/DomainPowerInstanceConfig'
+            - type: 'null'
         sidecars:
           description: Additional models with parameters or reports that are merged with the instance model
-          default: []
+          default: [ ]
           type: array
           items:
             $ref: '#/components/schemas/ModelId'
@@ -2095,14 +2095,14 @@ components:
       description: Fixed instance node specification
       type: object
       required:
-      - instance_id
-      - parameters
-      - wet
+        - instance_id
+        - parameters
+        - wet
       properties:
         instance_id:
           description: The manufacturer, name and instance identifier of the hardware device doing the processing
           allOf:
-          - $ref: '#/components/schemas/FixedInstanceId'
+            - $ref: '#/components/schemas/FixedInstanceId'
         parameters:
           description: parameters
         wet:
@@ -2117,35 +2117,35 @@ components:
     InputPadId:
       description: A pad that can receive connections on a node inside a task
       oneOf:
-      - description: Mixer node input
-        type: object
-        required:
-        - mixer
-        properties:
-          mixer:
-            $ref: '#/components/schemas/MixerNodeId'
-        additionalProperties: false
-      - description: Fixed instance node input
-        type: object
-        required:
-        - fixed
-        properties:
-          fixed:
-            $ref: '#/components/schemas/FixedInstanceNodeId'
-        additionalProperties: false
-      - description: Dynamic instance node input
-        type: object
-        required:
-        - dynamic
-        properties:
-          dynamic:
-            $ref: '#/components/schemas/DynamicInstanceNodeId'
-        additionalProperties: false
+        - description: Mixer node input
+          type: object
+          required:
+            - mixer
+          properties:
+            mixer:
+              $ref: '#/components/schemas/MixerNodeId'
+          additionalProperties: false
+        - description: Fixed instance node input
+          type: object
+          required:
+            - fixed
+          properties:
+            fixed:
+              $ref: '#/components/schemas/FixedInstanceNodeId'
+          additionalProperties: false
+        - description: Dynamic instance node input
+          type: object
+          required:
+            - dynamic
+          properties:
+            dynamic:
+              $ref: '#/components/schemas/DynamicInstanceNodeId'
+          additionalProperties: false
     InstanceDriverConfig:
       title: InstanceDriverConfig
       type: object
       required:
-      - instances
+        - instances
       properties:
         instances:
           type: object
@@ -2153,246 +2153,246 @@ components:
             $ref: '#/components/schemas/FixedInstanceConfig'
     InstanceDriverError:
       oneOf:
-      - type: string
-        enum:
-        - media_not_present
-        - not_power_controller
-        - not_interruptable
-      - type: object
-        required:
-        - instance_not_found
-        properties:
-          instance_not_found:
-            type: object
-            required:
-            - instance
-            properties:
-              instance:
-                $ref: '#/components/schemas/FixedInstanceId'
-        additionalProperties: false
-      - type: object
-        required:
-        - parameter_does_not_exist
-        properties:
-          parameter_does_not_exist:
-            type: object
-            required:
-            - error
-            properties:
-              error:
-                type: string
-        additionalProperties: false
-      - type: object
-        required:
-        - parameters_malformed
-        properties:
-          parameters_malformed:
-            type: object
-            required:
-            - error
-            properties:
-              error:
-                type: string
-        additionalProperties: false
-      - type: object
-        required:
-        - reports_malformed
-        properties:
-          reports_malformed:
-            type: object
-            required:
-            - error
-            properties:
-              error:
-                type: string
-        additionalProperties: false
-      - type: object
-        required:
-        - config_malformed
-        properties:
-          config_malformed:
-            type: object
-            required:
-            - error
-            properties:
-              error:
-                type: string
-        additionalProperties: false
-      - type: object
-        required:
-        - i_o_error
-        properties:
-          i_o_error:
-            type: object
-            required:
-            - error
-            properties:
-              error:
-                type: string
-        additionalProperties: false
-      - type: object
-        required:
-        - driver_not_supported
-        properties:
-          driver_not_supported:
-            type: object
-            required:
-            - manufacturer
-            - name
-            properties:
-              manufacturer:
-                type: string
-              name:
-                type: string
-        additionalProperties: false
-      - type: object
-        required:
-        - r_p_c
-        properties:
-          r_p_c:
-            type: object
-            required:
-            - error
-            properties:
-              error:
-                type: string
-        additionalProperties: false
+        - type: string
+          enum:
+            - media_not_present
+            - not_power_controller
+            - not_interruptable
+        - type: object
+          required:
+            - instance_not_found
+          properties:
+            instance_not_found:
+              type: object
+              required:
+                - instance
+              properties:
+                instance:
+                  $ref: '#/components/schemas/FixedInstanceId'
+          additionalProperties: false
+        - type: object
+          required:
+            - parameter_does_not_exist
+          properties:
+            parameter_does_not_exist:
+              type: object
+              required:
+                - error
+              properties:
+                error:
+                  type: string
+          additionalProperties: false
+        - type: object
+          required:
+            - parameters_malformed
+          properties:
+            parameters_malformed:
+              type: object
+              required:
+                - error
+              properties:
+                error:
+                  type: string
+          additionalProperties: false
+        - type: object
+          required:
+            - reports_malformed
+          properties:
+            reports_malformed:
+              type: object
+              required:
+                - error
+              properties:
+                error:
+                  type: string
+          additionalProperties: false
+        - type: object
+          required:
+            - config_malformed
+          properties:
+            config_malformed:
+              type: object
+              required:
+                - error
+              properties:
+                error:
+                  type: string
+          additionalProperties: false
+        - type: object
+          required:
+            - i_o_error
+          properties:
+            i_o_error:
+              type: object
+              required:
+                - error
+              properties:
+                error:
+                  type: string
+          additionalProperties: false
+        - type: object
+          required:
+            - driver_not_supported
+          properties:
+            driver_not_supported:
+              type: object
+              required:
+                - manufacturer
+                - name
+              properties:
+                manufacturer:
+                  type: string
+                name:
+                  type: string
+          additionalProperties: false
+        - type: object
+          required:
+            - r_p_c
+          properties:
+            r_p_c:
+              type: object
+              required:
+                - error
+              properties:
+                error:
+                  type: string
+          additionalProperties: false
     InstanceDriverId:
       type: string
     InstanceEvent:
       oneOf:
-      - type: object
-        required:
-        - state
-        properties:
-          state:
-            type: object
-            required:
-            - connected
-            properties:
-              connected:
-                $ref: '#/components/schemas/Timestamped_for_Boolean'
-              play:
-                anyOf:
-                - $ref: '#/components/schemas/ReportInstancePlayState'
-                - type: 'null'
-              power:
-                anyOf:
-                - $ref: '#/components/schemas/ReportInstancePowerState'
-                - type: 'null'
-        additionalProperties: false
-      - type: object
-        required:
-        - error
-        properties:
-          error:
-            type: object
-            required:
+        - type: object
+          required:
+            - state
+          properties:
+            state:
+              type: object
+              required:
+                - connected
+              properties:
+                connected:
+                  $ref: '#/components/schemas/Timestamped_for_Boolean'
+                play:
+                  anyOf:
+                    - $ref: '#/components/schemas/ReportInstancePlayState'
+                    - type: 'null'
+                power:
+                  anyOf:
+                    - $ref: '#/components/schemas/ReportInstancePowerState'
+                    - type: 'null'
+          additionalProperties: false
+        - type: object
+          required:
             - error
-            properties:
-              error:
-                type: string
-        additionalProperties: false
+          properties:
+            error:
+              type: object
+              required:
+                - error
+              properties:
+                error:
+                  type: string
+          additionalProperties: false
     InstancePlayState:
       oneOf:
-      - type: string
-        enum:
-        - stopping
-      - type: object
-        required:
-        - preparing_to_play
-        properties:
-          preparing_to_play:
-            type: object
-            required:
-            - play_id
-            properties:
-              play_id:
-                $ref: '#/components/schemas/PlayId'
-        additionalProperties: false
-      - type: object
-        required:
-        - playing
-        properties:
-          playing:
-            type: object
-            required:
-            - play_id
-            properties:
-              play_id:
-                $ref: '#/components/schemas/PlayId'
-        additionalProperties: false
-      - type: object
-        required:
-        - preparing_to_render
-        properties:
-          preparing_to_render:
-            type: object
-            required:
-            - length
-            - render_id
-            properties:
-              length:
-                type: number
-                format: double
-              render_id:
-                $ref: '#/components/schemas/RenderId'
-        additionalProperties: false
-      - type: object
-        required:
-        - rendering
-        properties:
-          rendering:
-            type: object
-            required:
-            - length
-            - render_id
-            properties:
-              length:
-                type: number
-                format: double
-              render_id:
-                $ref: '#/components/schemas/RenderId'
-        additionalProperties: false
-      - type: object
-        required:
-        - rewinding
-        properties:
-          rewinding:
-            type: object
-            required:
-            - to
-            properties:
-              to:
-                type: number
-                format: double
-        additionalProperties: false
-      - type: object
-        required:
-        - stopped
-        properties:
-          stopped:
-            type: object
-            properties:
-              position:
-                type:
-                - number
-                - 'null'
-                format: double
-        additionalProperties: false
+        - type: string
+          enum:
+            - stopping
+        - type: object
+          required:
+            - preparing_to_play
+          properties:
+            preparing_to_play:
+              type: object
+              required:
+                - play_id
+              properties:
+                play_id:
+                  $ref: '#/components/schemas/PlayId'
+          additionalProperties: false
+        - type: object
+          required:
+            - playing
+          properties:
+            playing:
+              type: object
+              required:
+                - play_id
+              properties:
+                play_id:
+                  $ref: '#/components/schemas/PlayId'
+          additionalProperties: false
+        - type: object
+          required:
+            - preparing_to_render
+          properties:
+            preparing_to_render:
+              type: object
+              required:
+                - length
+                - render_id
+              properties:
+                length:
+                  type: number
+                  format: double
+                render_id:
+                  $ref: '#/components/schemas/RenderId'
+          additionalProperties: false
+        - type: object
+          required:
+            - rendering
+          properties:
+            rendering:
+              type: object
+              required:
+                - length
+                - render_id
+              properties:
+                length:
+                  type: number
+                  format: double
+                render_id:
+                  $ref: '#/components/schemas/RenderId'
+          additionalProperties: false
+        - type: object
+          required:
+            - rewinding
+          properties:
+            rewinding:
+              type: object
+              required:
+                - to
+              properties:
+                to:
+                  type: number
+                  format: double
+          additionalProperties: false
+        - type: object
+          required:
+            - stopped
+          properties:
+            stopped:
+              type: object
+              properties:
+                position:
+                  type:
+                    - number
+                    - 'null'
+                  format: double
+          additionalProperties: false
     InstancePowerState:
       type: string
       enum:
-      - powering_up
-      - shutting_down
-      - powered_up
-      - shut_down
+        - powering_up
+        - shutting_down
+        - powered_up
+        - shut_down
     Maintenance:
       description: Maintenance window
       type: object
       required:
-      - reason
-      - time
+        - reason
+        - time
       properties:
         reason:
           description: Human readable string about it, or URL to a web page detailing more information
@@ -2400,26 +2400,26 @@ components:
         time:
           description: Time during which maintenance is taking place (may overlap with others)
           allOf:
-          - $ref: '#/components/schemas/TimeRange'
+            - $ref: '#/components/schemas/TimeRange'
     MediaChannels:
       description: Channel count for media items and track nodes
       oneOf:
-      - description: Single channel
-        type: string
-        enum:
-        - mono
-      - description: Two channels - left and right
-        type: string
-        enum:
-        - stereo
+        - description: Single channel
+          type: string
+          enum:
+            - mono
+        - description: Two channels - left and right
+          type: string
+          enum:
+            - stereo
     MediaMetadata:
       type: object
       required:
-      - bytes
-      - channels
-      - format
-      - sample_rate
-      - seconds
+        - bytes
+        - channels
+        - format
+        - sample_rate
+        - seconds
       properties:
         bytes:
           type: integer
@@ -2439,24 +2439,24 @@ components:
     MediaObject:
       type: object
       required:
-      - id
-      - revision
+        - id
+        - revision
       properties:
         id:
           $ref: '#/components/schemas/AppMediaObjectId'
         last_used:
           type:
-          - string
-          - 'null'
+            - string
+            - 'null'
           format: date-time
         metadata:
           anyOf:
-          - $ref: '#/components/schemas/MediaMetadata'
-          - type: 'null'
+            - $ref: '#/components/schemas/MediaMetadata'
+            - type: 'null'
         path:
           type:
-          - string
-          - 'null'
+            - string
+            - 'null'
         revision:
           type: integer
           format: uint64
@@ -2467,8 +2467,8 @@ components:
       description: Mixer node specification
       type: object
       required:
-      - input_channels
-      - output_channels
+        - input_channels
+        - output_channels
       properties:
         input_channels:
           description: Numvber of input channels on the mixer node
@@ -2489,7 +2489,7 @@ components:
       description: Request to modify a task on the domain
       type: object
       required:
-      - modify_spec
+        - modify_spec
       properties:
         modify_spec:
           description: A list of modifications to apply
@@ -2498,514 +2498,514 @@ components:
             $ref: '#/components/schemas/ModifyTaskSpec'
     ModifyTaskError:
       oneOf:
-      - type: object
-        required:
-        - node_id
-        - type
-        properties:
-          node_id:
-            $ref: '#/components/schemas/TrackNodeId'
-          type:
-            type: string
-            enum:
-            - track_exists
-      - type: object
-        required:
-        - node_id
-        - type
-        properties:
-          node_id:
-            $ref: '#/components/schemas/FixedInstanceNodeId'
-          type:
-            type: string
-            enum:
-            - fixed_instance_exists
-      - type: object
-        required:
-        - node_id
-        - type
-        properties:
-          node_id:
-            $ref: '#/components/schemas/DynamicInstanceNodeId'
-          type:
-            type: string
-            enum:
-            - dynamic_instance_exists
-      - type: object
-        required:
-        - node_id
-        - type
-        properties:
-          node_id:
-            $ref: '#/components/schemas/MixerNodeId'
-          type:
-            type: string
-            enum:
-            - mixer_exists
-      - type: object
-        required:
-        - node_id
-        - type
-        properties:
-          node_id:
-            $ref: '#/components/schemas/TrackNodeId'
-          type:
-            type: string
-            enum:
-            - track_does_not_exist
-      - type: object
-        required:
-        - node_id
-        - type
-        properties:
-          node_id:
-            $ref: '#/components/schemas/FixedInstanceNodeId'
-          type:
-            type: string
-            enum:
-            - fixed_instance_does_not_exist
-      - type: object
-        required:
-        - node_id
-        - type
-        properties:
-          node_id:
-            $ref: '#/components/schemas/DynamicInstanceNodeId'
-          type:
-            type: string
-            enum:
-            - dynamic_instance_does_not_exist
-      - type: object
-        required:
-        - node_id
-        - type
-        properties:
-          node_id:
-            $ref: '#/components/schemas/MixerNodeId'
-          type:
-            type: string
-            enum:
-            - mixer_does_not_exist
-      - type: object
-        required:
-        - connection_id
-        - type
-        properties:
-          connection_id:
-            $ref: '#/components/schemas/NodeConnectionId'
-          type:
-            type: string
-            enum:
-            - connection_does_not_exist
-      - type: object
-        required:
-        - connection_id
-        - type
-        properties:
-          connection_id:
-            $ref: '#/components/schemas/NodeConnectionId'
-          type:
-            type: string
-            enum:
-            - connection_exists
-      - type: object
-        required:
-        - connection_id
-        - message
-        - type
-        properties:
-          connection_id:
-            $ref: '#/components/schemas/NodeConnectionId'
-          message:
-            type: string
-          type:
-            type: string
-            enum:
-            - connection_malformed
-      - type: object
-        required:
-        - media_id
-        - node_id
-        - type
-        properties:
-          media_id:
-            $ref: '#/components/schemas/TrackMediaId'
-          node_id:
-            $ref: '#/components/schemas/TrackNodeId'
-          type:
-            type: string
-            enum:
-            - media_exists
-      - type: object
-        required:
-        - media_id
-        - node_id
-        - type
-        properties:
-          media_id:
-            $ref: '#/components/schemas/TrackMediaId'
-          node_id:
-            $ref: '#/components/schemas/TrackNodeId'
-          type:
-            type: string
-            enum:
-            - media_does_not_exist
-      - type: object
-        required:
-        - type
-        properties:
-          type:
-            type: string
-            enum:
-            - cycle_detected
+        - type: object
+          required:
+            - node_id
+            - type
+          properties:
+            node_id:
+              $ref: '#/components/schemas/TrackNodeId'
+            type:
+              type: string
+              enum:
+                - track_exists
+        - type: object
+          required:
+            - node_id
+            - type
+          properties:
+            node_id:
+              $ref: '#/components/schemas/FixedInstanceNodeId'
+            type:
+              type: string
+              enum:
+                - fixed_instance_exists
+        - type: object
+          required:
+            - node_id
+            - type
+          properties:
+            node_id:
+              $ref: '#/components/schemas/DynamicInstanceNodeId'
+            type:
+              type: string
+              enum:
+                - dynamic_instance_exists
+        - type: object
+          required:
+            - node_id
+            - type
+          properties:
+            node_id:
+              $ref: '#/components/schemas/MixerNodeId'
+            type:
+              type: string
+              enum:
+                - mixer_exists
+        - type: object
+          required:
+            - node_id
+            - type
+          properties:
+            node_id:
+              $ref: '#/components/schemas/TrackNodeId'
+            type:
+              type: string
+              enum:
+                - track_does_not_exist
+        - type: object
+          required:
+            - node_id
+            - type
+          properties:
+            node_id:
+              $ref: '#/components/schemas/FixedInstanceNodeId'
+            type:
+              type: string
+              enum:
+                - fixed_instance_does_not_exist
+        - type: object
+          required:
+            - node_id
+            - type
+          properties:
+            node_id:
+              $ref: '#/components/schemas/DynamicInstanceNodeId'
+            type:
+              type: string
+              enum:
+                - dynamic_instance_does_not_exist
+        - type: object
+          required:
+            - node_id
+            - type
+          properties:
+            node_id:
+              $ref: '#/components/schemas/MixerNodeId'
+            type:
+              type: string
+              enum:
+                - mixer_does_not_exist
+        - type: object
+          required:
+            - connection_id
+            - type
+          properties:
+            connection_id:
+              $ref: '#/components/schemas/NodeConnectionId'
+            type:
+              type: string
+              enum:
+                - connection_does_not_exist
+        - type: object
+          required:
+            - connection_id
+            - type
+          properties:
+            connection_id:
+              $ref: '#/components/schemas/NodeConnectionId'
+            type:
+              type: string
+              enum:
+                - connection_exists
+        - type: object
+          required:
+            - connection_id
+            - message
+            - type
+          properties:
+            connection_id:
+              $ref: '#/components/schemas/NodeConnectionId'
+            message:
+              type: string
+            type:
+              type: string
+              enum:
+                - connection_malformed
+        - type: object
+          required:
+            - media_id
+            - node_id
+            - type
+          properties:
+            media_id:
+              $ref: '#/components/schemas/TrackMediaId'
+            node_id:
+              $ref: '#/components/schemas/TrackNodeId'
+            type:
+              type: string
+              enum:
+                - media_exists
+        - type: object
+          required:
+            - media_id
+            - node_id
+            - type
+          properties:
+            media_id:
+              $ref: '#/components/schemas/TrackMediaId'
+            node_id:
+              $ref: '#/components/schemas/TrackNodeId'
+            type:
+              type: string
+              enum:
+                - media_does_not_exist
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - cycle_detected
     ModifyTaskSpec:
       description: Modify task structure
       oneOf:
-      - description: Add a track node to the task
-        type: object
-        required:
-        - add_track
-        properties:
-          add_track:
-            type: object
-            required:
-            - channels
-            - track_id
-            properties:
-              channels:
-                description: Number of channels for the track node
-                allOf:
-                - $ref: '#/components/schemas/MediaChannels'
-              track_id:
-                description: New track node id
-                allOf:
-                - $ref: '#/components/schemas/TrackNodeId'
-        additionalProperties: false
-      - description: Add media to a track node
-        type: object
-        required:
-        - add_track_media
-        properties:
-          add_track_media:
-            type: object
-            required:
-            - media_id
-            - spec
-            - track_id
-            properties:
-              media_id:
-                description: Media id within the track node
-                allOf:
-                - $ref: '#/components/schemas/TrackMediaId'
-              spec:
-                description: Media object specification
-                allOf:
-                - $ref: '#/components/schemas/TrackMedia'
-              track_id:
-                description: Track node id
-                allOf:
-                - $ref: '#/components/schemas/TrackNodeId'
-        additionalProperties: false
-      - description: Update track media on a track node
-        type: object
-        required:
-        - update_track_media
-        properties:
-          update_track_media:
-            type: object
-            required:
-            - media_id
-            - track_id
-            - update
-            properties:
-              media_id:
-                description: Media id within the track node
-                allOf:
-                - $ref: '#/components/schemas/TrackMediaId'
-              track_id:
-                description: Track node id
-                allOf:
-                - $ref: '#/components/schemas/TrackNodeId'
-              update:
-                description: Media object update
-                allOf:
-                - $ref: '#/components/schemas/UpdateTaskTrackMedia'
-        additionalProperties: false
-      - description: Delete track media from a track node
-        type: object
-        required:
-        - delete_track_media
-        properties:
-          delete_track_media:
-            type: object
-            required:
-            - media_id
-            - track_id
-            properties:
-              media_id:
-                description: Media id within the track node
-                allOf:
-                - $ref: '#/components/schemas/TrackMediaId'
-              track_id:
-                description: Track node id
-                allOf:
-                - $ref: '#/components/schemas/TrackNodeId'
-        additionalProperties: false
-      - description: Delete a track node from the task (including all media and referencing connections)
-        type: object
-        required:
-        - delete_track
-        properties:
-          delete_track:
-            type: object
-            required:
-            - track_id
-            properties:
-              track_id:
-                description: Track node id
-                allOf:
-                - $ref: '#/components/schemas/TrackNodeId'
-        additionalProperties: false
-      - description: Add a fixed instance node to the task
-        type: object
-        required:
-        - add_fixed_instance
-        properties:
-          add_fixed_instance:
-            type: object
-            required:
-            - fixed_id
-            - spec
-            properties:
-              fixed_id:
-                description: Fixed instance node id
-                allOf:
-                - $ref: '#/components/schemas/FixedInstanceNodeId'
-              spec:
-                description: Fixed instance node processing specification
-                allOf:
-                - $ref: '#/components/schemas/FixedInstanceNode'
-        additionalProperties: false
-      - description: Add a dynamic instance node to the task
-        type: object
-        required:
-        - add_dynamic_instance
-        properties:
-          add_dynamic_instance:
-            type: object
-            required:
-            - dynamic_id
-            - spec
-            properties:
-              dynamic_id:
-                description: Dynamic instance node id
-                allOf:
-                - $ref: '#/components/schemas/DynamicInstanceNodeId'
-              spec:
-                description: Dynamic instance node processing specification
-                allOf:
-                - $ref: '#/components/schemas/DynamicInstanceNode'
-        additionalProperties: false
-      - description: Add a mixer node to the task
-        type: object
-        required:
-        - add_mixer
-        properties:
-          add_mixer:
-            type: object
-            required:
-            - mixer_id
-            - spec
-            properties:
-              mixer_id:
-                description: Mixer node id
-                allOf:
-                - $ref: '#/components/schemas/MixerNodeId'
-              spec:
-                description: Mixer node processing specification
-                allOf:
-                - $ref: '#/components/schemas/MixerNode'
-        additionalProperties: false
-      - description: Delete a mixer node from the task (including all referencing connections)
-        type: object
-        required:
-        - delete_mixer
-        properties:
-          delete_mixer:
-            type: object
-            required:
-            - mixer_id
-            properties:
-              mixer_id:
-                description: Moxer node id
-                allOf:
-                - $ref: '#/components/schemas/MixerNodeId'
-        additionalProperties: false
-      - description: Delete a fixed instance node from the task (including all referencing connections)
-        type: object
-        required:
-        - delete_fixed_instance
-        properties:
-          delete_fixed_instance:
-            type: object
-            required:
-            - fixed_id
-            properties:
-              fixed_id:
-                description: Fixed instance node id
-                allOf:
-                - $ref: '#/components/schemas/FixedInstanceNodeId'
-        additionalProperties: false
-      - description: Delete dynamic instance node from the task (including all referencing connections)
-        type: object
-        required:
-        - delete_dynamic_instance
-        properties:
-          delete_dynamic_instance:
-            type: object
-            required:
-            - dynamic_id
-            properties:
-              dynamic_id:
-                description: Dynamic instance node id
-                allOf:
-                - $ref: '#/components/schemas/DynamicInstanceNodeId'
-        additionalProperties: false
-      - description: Delete a connection from the task (preserving the referenced nodes even if they are now unconnected)
-        type: object
-        required:
-        - delete_connection
-        properties:
-          delete_connection:
-            type: object
-            required:
-            - connection_id
-            properties:
-              connection_id:
-                description: Connection id
-                allOf:
-                - $ref: '#/components/schemas/NodeConnectionId'
-        additionalProperties: false
-      - description: Add a connection to the task
-        type: object
-        required:
-        - add_connection
-        properties:
-          add_connection:
-            type: object
-            required:
-            - connection_id
-            - from
-            - from_channels
-            - pan
-            - to
-            - to_channels
-            - volume
-            properties:
-              connection_id:
-                description: Connection id
-                allOf:
-                - $ref: '#/components/schemas/NodeConnectionId'
-              from:
-                description: Source node pad
-                allOf:
-                - $ref: '#/components/schemas/OutputPadId'
-              from_channels:
-                description: Source channel mask
-                allOf:
-                - $ref: '#/components/schemas/ChannelMask'
-              pan:
-                description: Panning adjustment on the audio passing through the connection
-                type: number
-                format: double
-              to:
-                description: Destination node pad
-                allOf:
-                - $ref: '#/components/schemas/InputPadId'
-              to_channels:
-                description: Destination channel mask
-                allOf:
-                - $ref: '#/components/schemas/ChannelMask'
-              volume:
-                description: Volume adjustment on audio passing through the connection
-                type: number
-                format: double
-        additionalProperties: false
-      - description: Set connection values
-        type: object
-        required:
-        - set_connection_parameter_values
-        properties:
-          set_connection_parameter_values:
-            type: object
-            required:
-            - connection_id
-            - values
-            properties:
-              connection_id:
-                description: Connection id
-                allOf:
-                - $ref: '#/components/schemas/NodeConnectionId'
-              values:
-                description: Values (parameters) on the connection
-                allOf:
-                - $ref: '#/components/schemas/ConnectionValues'
-        additionalProperties: false
-      - description: Set fixed instance node values
-        type: object
-        required:
-        - set_fixed_instance_parameter_values
-        properties:
-          set_fixed_instance_parameter_values:
-            type: object
-            required:
-            - fixed_id
-            - values
-            properties:
-              fixed_id:
-                description: Fixed instance node id
-                allOf:
-                - $ref: '#/components/schemas/FixedInstanceNodeId'
-              values:
-                description: Values to set
-        additionalProperties: false
-      - description: Set dynamic instance node values
-        type: object
-        required:
-        - set_dynamic_instance_parameter_values
-        properties:
-          set_dynamic_instance_parameter_values:
-            type: object
-            required:
-            - dynamic_id
-            - values
-            properties:
-              dynamic_id:
-                description: Dynamic instance node id
-                allOf:
-                - $ref: '#/components/schemas/DynamicInstanceNodeId'
-              values:
-                description: Values to set
-        additionalProperties: false
+        - description: Add a track node to the task
+          type: object
+          required:
+            - add_track
+          properties:
+            add_track:
+              type: object
+              required:
+                - channels
+                - track_id
+              properties:
+                channels:
+                  description: Number of channels for the track node
+                  allOf:
+                    - $ref: '#/components/schemas/MediaChannels'
+                track_id:
+                  description: New track node id
+                  allOf:
+                    - $ref: '#/components/schemas/TrackNodeId'
+          additionalProperties: false
+        - description: Add media to a track node
+          type: object
+          required:
+            - add_track_media
+          properties:
+            add_track_media:
+              type: object
+              required:
+                - media_id
+                - spec
+                - track_id
+              properties:
+                media_id:
+                  description: Media id within the track node
+                  allOf:
+                    - $ref: '#/components/schemas/TrackMediaId'
+                spec:
+                  description: Media object specification
+                  allOf:
+                    - $ref: '#/components/schemas/TrackMedia'
+                track_id:
+                  description: Track node id
+                  allOf:
+                    - $ref: '#/components/schemas/TrackNodeId'
+          additionalProperties: false
+        - description: Update track media on a track node
+          type: object
+          required:
+            - update_track_media
+          properties:
+            update_track_media:
+              type: object
+              required:
+                - media_id
+                - track_id
+                - update
+              properties:
+                media_id:
+                  description: Media id within the track node
+                  allOf:
+                    - $ref: '#/components/schemas/TrackMediaId'
+                track_id:
+                  description: Track node id
+                  allOf:
+                    - $ref: '#/components/schemas/TrackNodeId'
+                update:
+                  description: Media object update
+                  allOf:
+                    - $ref: '#/components/schemas/UpdateTaskTrackMedia'
+          additionalProperties: false
+        - description: Delete track media from a track node
+          type: object
+          required:
+            - delete_track_media
+          properties:
+            delete_track_media:
+              type: object
+              required:
+                - media_id
+                - track_id
+              properties:
+                media_id:
+                  description: Media id within the track node
+                  allOf:
+                    - $ref: '#/components/schemas/TrackMediaId'
+                track_id:
+                  description: Track node id
+                  allOf:
+                    - $ref: '#/components/schemas/TrackNodeId'
+          additionalProperties: false
+        - description: Delete a track node from the task (including all media and referencing connections)
+          type: object
+          required:
+            - delete_track
+          properties:
+            delete_track:
+              type: object
+              required:
+                - track_id
+              properties:
+                track_id:
+                  description: Track node id
+                  allOf:
+                    - $ref: '#/components/schemas/TrackNodeId'
+          additionalProperties: false
+        - description: Add a fixed instance node to the task
+          type: object
+          required:
+            - add_fixed_instance
+          properties:
+            add_fixed_instance:
+              type: object
+              required:
+                - fixed_id
+                - spec
+              properties:
+                fixed_id:
+                  description: Fixed instance node id
+                  allOf:
+                    - $ref: '#/components/schemas/FixedInstanceNodeId'
+                spec:
+                  description: Fixed instance node processing specification
+                  allOf:
+                    - $ref: '#/components/schemas/FixedInstanceNode'
+          additionalProperties: false
+        - description: Add a dynamic instance node to the task
+          type: object
+          required:
+            - add_dynamic_instance
+          properties:
+            add_dynamic_instance:
+              type: object
+              required:
+                - dynamic_id
+                - spec
+              properties:
+                dynamic_id:
+                  description: Dynamic instance node id
+                  allOf:
+                    - $ref: '#/components/schemas/DynamicInstanceNodeId'
+                spec:
+                  description: Dynamic instance node processing specification
+                  allOf:
+                    - $ref: '#/components/schemas/DynamicInstanceNode'
+          additionalProperties: false
+        - description: Add a mixer node to the task
+          type: object
+          required:
+            - add_mixer
+          properties:
+            add_mixer:
+              type: object
+              required:
+                - mixer_id
+                - spec
+              properties:
+                mixer_id:
+                  description: Mixer node id
+                  allOf:
+                    - $ref: '#/components/schemas/MixerNodeId'
+                spec:
+                  description: Mixer node processing specification
+                  allOf:
+                    - $ref: '#/components/schemas/MixerNode'
+          additionalProperties: false
+        - description: Delete a mixer node from the task (including all referencing connections)
+          type: object
+          required:
+            - delete_mixer
+          properties:
+            delete_mixer:
+              type: object
+              required:
+                - mixer_id
+              properties:
+                mixer_id:
+                  description: Moxer node id
+                  allOf:
+                    - $ref: '#/components/schemas/MixerNodeId'
+          additionalProperties: false
+        - description: Delete a fixed instance node from the task (including all referencing connections)
+          type: object
+          required:
+            - delete_fixed_instance
+          properties:
+            delete_fixed_instance:
+              type: object
+              required:
+                - fixed_id
+              properties:
+                fixed_id:
+                  description: Fixed instance node id
+                  allOf:
+                    - $ref: '#/components/schemas/FixedInstanceNodeId'
+          additionalProperties: false
+        - description: Delete dynamic instance node from the task (including all referencing connections)
+          type: object
+          required:
+            - delete_dynamic_instance
+          properties:
+            delete_dynamic_instance:
+              type: object
+              required:
+                - dynamic_id
+              properties:
+                dynamic_id:
+                  description: Dynamic instance node id
+                  allOf:
+                    - $ref: '#/components/schemas/DynamicInstanceNodeId'
+          additionalProperties: false
+        - description: Delete a connection from the task (preserving the referenced nodes even if they are now unconnected)
+          type: object
+          required:
+            - delete_connection
+          properties:
+            delete_connection:
+              type: object
+              required:
+                - connection_id
+              properties:
+                connection_id:
+                  description: Connection id
+                  allOf:
+                    - $ref: '#/components/schemas/NodeConnectionId'
+          additionalProperties: false
+        - description: Add a connection to the task
+          type: object
+          required:
+            - add_connection
+          properties:
+            add_connection:
+              type: object
+              required:
+                - connection_id
+                - from
+                - from_channels
+                - pan
+                - to
+                - to_channels
+                - volume
+              properties:
+                connection_id:
+                  description: Connection id
+                  allOf:
+                    - $ref: '#/components/schemas/NodeConnectionId'
+                from:
+                  description: Source node pad
+                  allOf:
+                    - $ref: '#/components/schemas/OutputPadId'
+                from_channels:
+                  description: Source channel mask
+                  allOf:
+                    - $ref: '#/components/schemas/ChannelMask'
+                pan:
+                  description: Panning adjustment on the audio passing through the connection
+                  type: number
+                  format: double
+                to:
+                  description: Destination node pad
+                  allOf:
+                    - $ref: '#/components/schemas/InputPadId'
+                to_channels:
+                  description: Destination channel mask
+                  allOf:
+                    - $ref: '#/components/schemas/ChannelMask'
+                volume:
+                  description: Volume adjustment on audio passing through the connection
+                  type: number
+                  format: double
+          additionalProperties: false
+        - description: Set connection values
+          type: object
+          required:
+            - set_connection_parameter_values
+          properties:
+            set_connection_parameter_values:
+              type: object
+              required:
+                - connection_id
+                - values
+              properties:
+                connection_id:
+                  description: Connection id
+                  allOf:
+                    - $ref: '#/components/schemas/NodeConnectionId'
+                values:
+                  description: Values (parameters) on the connection
+                  allOf:
+                    - $ref: '#/components/schemas/ConnectionValues'
+          additionalProperties: false
+        - description: Set fixed instance node values
+          type: object
+          required:
+            - set_fixed_instance_parameter_values
+          properties:
+            set_fixed_instance_parameter_values:
+              type: object
+              required:
+                - fixed_id
+                - values
+              properties:
+                fixed_id:
+                  description: Fixed instance node id
+                  allOf:
+                    - $ref: '#/components/schemas/FixedInstanceNodeId'
+                values:
+                  description: Values to set
+          additionalProperties: false
+        - description: Set dynamic instance node values
+          type: object
+          required:
+            - set_dynamic_instance_parameter_values
+          properties:
+            set_dynamic_instance_parameter_values:
+              type: object
+              required:
+                - dynamic_id
+                - values
+              properties:
+                dynamic_id:
+                  description: Dynamic instance node id
+                  allOf:
+                    - $ref: '#/components/schemas/DynamicInstanceNodeId'
+                values:
+                  description: Values to set
+          additionalProperties: false
     NodeConnection:
       description: Connection between nodes in a task
       type: object
       required:
-      - from
-      - from_channels
-      - pan
-      - to
-      - to_channels
-      - volume
+        - from
+        - from_channels
+        - pan
+        - to
+        - to_channels
+        - volume
       properties:
         from:
           description: Source node pad
           allOf:
-          - $ref: '#/components/schemas/OutputPadId'
+            - $ref: '#/components/schemas/OutputPadId'
         from_channels:
           description: Source channel mask
           allOf:
-          - $ref: '#/components/schemas/ChannelMask'
+            - $ref: '#/components/schemas/ChannelMask'
         pan:
           description: |-
             Panning adjustment
@@ -3016,11 +3016,11 @@ components:
         to:
           description: Destination node pad
           allOf:
-          - $ref: '#/components/schemas/InputPadId'
+            - $ref: '#/components/schemas/InputPadId'
         to_channels:
           description: Destination channel mask
           allOf:
-          - $ref: '#/components/schemas/ChannelMask'
+            - $ref: '#/components/schemas/ChannelMask'
         volume:
           description: Volume adjustment as a factor
           type: number
@@ -3030,42 +3030,42 @@ components:
     OutputPadId:
       description: A pad that can receive connections on a node inside a task
       oneOf:
-      - description: Mixer node output
-        type: object
-        required:
-        - mixer
-        properties:
-          mixer:
-            $ref: '#/components/schemas/MixerNodeId'
-        additionalProperties: false
-      - description: Fixed instance node output
-        type: object
-        required:
-        - fixed
-        properties:
-          fixed:
-            $ref: '#/components/schemas/FixedInstanceNodeId'
-        additionalProperties: false
-      - description: Dynamic instance node output
-        type: object
-        required:
-        - dynamic
-        properties:
-          dynamic:
-            $ref: '#/components/schemas/DynamicInstanceNodeId'
-        additionalProperties: false
-      - description: Track node output
-        type: object
-        required:
-        - track
-        properties:
-          track:
-            $ref: '#/components/schemas/TrackNodeId'
-        additionalProperties: false
+        - description: Mixer node output
+          type: object
+          required:
+            - mixer
+          properties:
+            mixer:
+              $ref: '#/components/schemas/MixerNodeId'
+          additionalProperties: false
+        - description: Fixed instance node output
+          type: object
+          required:
+            - fixed
+          properties:
+            fixed:
+              $ref: '#/components/schemas/FixedInstanceNodeId'
+          additionalProperties: false
+        - description: Dynamic instance node output
+          type: object
+          required:
+            - dynamic
+          properties:
+            dynamic:
+              $ref: '#/components/schemas/DynamicInstanceNodeId'
+          additionalProperties: false
+        - description: Track node output
+          type: object
+          required:
+            - track
+          properties:
+            track:
+              $ref: '#/components/schemas/TrackNodeId'
+          additionalProperties: false
     PadMetering:
       type: object
       required:
-      - volume
+        - volume
       properties:
         volume:
           type: array
@@ -3075,30 +3075,30 @@ components:
     PeerConnectionCreated:
       description: Confirmation that the socket has been created normally from the domain client offer
       oneOf:
-      - description: Connection created normally
-        type: object
-        required:
-        - created
-        properties:
-          created:
-            type: object
-            required:
-            - remote_description
-            - socket_id
-            properties:
-              remote_description:
-                description: The domain server's WebRTC offer
-                type: string
-              socket_id:
-                description: Created socket id
-                allOf:
-                - $ref: '#/components/schemas/ClientSocketId'
-        additionalProperties: false
+        - description: Connection created normally
+          type: object
+          required:
+            - created
+          properties:
+            created:
+              type: object
+              required:
+                - remote_description
+                - socket_id
+              properties:
+                remote_description:
+                  description: The domain server's WebRTC offer
+                  type: string
+                socket_id:
+                  description: Created socket id
+                  allOf:
+                    - $ref: '#/components/schemas/ClientSocketId'
+          additionalProperties: false
     PlayBitDepth:
       type: string
       enum:
-      - '24'
-      - '16'
+        - '24'
+        - '16'
     PlayId:
       type: string
     RenderId:
@@ -3106,9 +3106,9 @@ components:
     ReportInstancePlayState:
       type: object
       required:
-      - actual
-      - desired
-      - media
+        - actual
+        - desired
+        - media
       properties:
         actual:
           $ref: '#/components/schemas/Timestamped_for_InstancePlayState'
@@ -3119,8 +3119,8 @@ components:
     ReportInstancePowerState:
       type: object
       required:
-      - actual
-      - desired
+        - actual
+        - desired
       properties:
         actual:
           $ref: '#/components/schemas/Timestamped_for_InstancePowerState'
@@ -3130,7 +3130,7 @@ components:
       title: RequestCancelRender
       type: object
       required:
-      - render_id
+        - render_id
       properties:
         render_id:
           $ref: '#/components/schemas/RenderId'
@@ -3138,8 +3138,8 @@ components:
       title: RequestChangeMixer
       type: object
       required:
-      - mixer_id
-      - play_id
+        - mixer_id
+        - play_id
       properties:
         mixer_id:
           $ref: '#/components/schemas/MixerNodeId'
@@ -3151,13 +3151,13 @@ components:
       title: RequestPlay
       type: object
       required:
-      - bit_depth
-      - looping
-      - mixer_id
-      - play_id
-      - sample_rate
-      - segment
-      - start_at
+        - bit_depth
+        - looping
+        - mixer_id
+        - play_id
+        - sample_rate
+        - segment
+        - start_at
       properties:
         bit_depth:
           $ref: '#/components/schemas/PlayBitDepth'
@@ -3177,10 +3177,10 @@ components:
     RequestRender:
       type: object
       required:
-      - mixer_id
-      - object_id
-      - render_id
-      - segment
+        - mixer_id
+        - object_id
+        - render_id
+        - segment
       properties:
         mixer_id:
           $ref: '#/components/schemas/MixerNodeId'
@@ -3194,10 +3194,10 @@ components:
       title: RequestSeek
       type: object
       required:
-      - looping
-      - play_id
-      - segment
-      - start_at
+        - looping
+        - play_id
+        - segment
+        - start_at
       properties:
         looping:
           type: boolean
@@ -3212,90 +3212,90 @@ components:
       title: RequestStopPlay
       type: object
       required:
-      - play_id
+        - play_id
       properties:
         play_id:
           $ref: '#/components/schemas/PlayId'
     SampleRate:
       type: string
       enum:
-      - '192'
-      - '96'
-      - '88.2'
-      - '48'
-      - '44.1'
+        - '192'
+        - '96'
+        - '88.2'
+        - '48'
+        - '44.1'
     SecureKey:
       type: string
     SerializableResult_for_Null_and_DomainError:
       oneOf:
-      - type: object
-        required:
-        - ok
-        properties:
-          ok:
-            type: 'null'
-        additionalProperties: false
-      - type: object
-        required:
-        - error
-        properties:
-          error:
-            $ref: '#/components/schemas/DomainError'
-        additionalProperties: false
+        - type: object
+          required:
+            - ok
+          properties:
+            ok:
+              type: 'null'
+          additionalProperties: false
+        - type: object
+          required:
+            - error
+          properties:
+            error:
+              $ref: '#/components/schemas/DomainError'
+          additionalProperties: false
     SerializableResult_for_PeerConnectionCreated_and_DomainError:
       oneOf:
-      - type: object
-        required:
-        - ok
-        properties:
-          ok:
-            $ref: '#/components/schemas/PeerConnectionCreated'
-        additionalProperties: false
-      - type: object
-        required:
-        - error
-        properties:
-          error:
-            $ref: '#/components/schemas/DomainError'
-        additionalProperties: false
+        - type: object
+          required:
+            - ok
+          properties:
+            ok:
+              $ref: '#/components/schemas/PeerConnectionCreated'
+          additionalProperties: false
+        - type: object
+          required:
+            - error
+          properties:
+            error:
+              $ref: '#/components/schemas/DomainError'
+          additionalProperties: false
     SerializableResult_for_TaskUpdated_and_DomainError:
       oneOf:
-      - type: object
-        required:
-        - ok
-        properties:
-          ok:
-            $ref: '#/components/schemas/TaskUpdated'
-        additionalProperties: false
-      - type: object
-        required:
-        - error
-        properties:
-          error:
-            $ref: '#/components/schemas/DomainError'
-        additionalProperties: false
+        - type: object
+          required:
+            - ok
+          properties:
+            ok:
+              $ref: '#/components/schemas/TaskUpdated'
+          additionalProperties: false
+        - type: object
+          required:
+            - error
+          properties:
+            error:
+              $ref: '#/components/schemas/DomainError'
+          additionalProperties: false
     SocketId:
       type: string
     StreamStats:
       title: StreamStats
       type: object
       required:
-      - id
-      - play_id
-      - state
+        - id
+        - play_id
+        - state
       properties:
         high:
           type:
-          - integer
-          - 'null'
+            - integer
+            - 'null'
           format: uint64
           minimum: 0.0
         id:
           $ref: '#/components/schemas/AppTaskId'
         low:
           type:
-          - integer
-          - 'null'
+            - integer
+            - 'null'
           format: uint64
           minimum: 0.0
         play_id:
@@ -3306,14 +3306,14 @@ components:
       title: StreamingPacket
       type: object
       required:
-      - audio
-      - created_at
-      - instance_metering
-      - pad_metering
-      - play_id
-      - serial
-      - streaming_pos
-      - timeline_pos
+        - audio
+        - created_at
+        - instance_metering
+        - pad_metering
+        - play_id
+        - serial
+        - streaming_pos
+        - timeline_pos
       properties:
         audio:
           type: array
@@ -3351,116 +3351,116 @@ components:
       description: Task information
       type: object
       required:
-      - domain_id
-      - reservations
-      - security
-      - spec
+        - domain_id
+        - reservations
+        - security
+        - spec
       properties:
         domain_id:
           description: Domain executing the task
           allOf:
-          - $ref: '#/components/schemas/DomainId'
+            - $ref: '#/components/schemas/DomainId'
         reservations:
           description: Task reservations
           allOf:
-          - $ref: '#/components/schemas/TaskReservation'
+            - $ref: '#/components/schemas/TaskReservation'
         security:
           description: Security keys and associateds permissions
           allOf:
-          - $ref: '#/components/schemas/TaskSecurity'
+            - $ref: '#/components/schemas/TaskSecurity'
         spec:
           description: Task specification
           allOf:
-          - $ref: '#/components/schemas/TaskSpec'
+            - $ref: '#/components/schemas/TaskSpec'
     TaskCreated:
       title: TaskCreated
       description: Response to creating a task on the domain
       oneOf:
-      - description: Created normally
-        type: object
-        required:
-        - created
-        properties:
-          created:
-            type: object
-            required:
-            - task_id
-            properties:
-              task_id:
-                description: Task Id
-                allOf:
-                - $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
+        - description: Created normally
+          type: object
+          required:
+            - created
+          properties:
+            created:
+              type: object
+              required:
+                - task_id
+              properties:
+                task_id:
+                  description: Task Id
+                  allOf:
+                    - $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
     TaskDeleted:
       title: TaskDeleted
       oneOf:
-      - type: object
-        required:
-        - deleted
-        properties:
-          deleted:
-            type: object
-            required:
-            - id
-            properties:
-              id:
-                $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
+        - type: object
+          required:
+            - deleted
+          properties:
+            deleted:
+              type: object
+              required:
+                - id
+              properties:
+                id:
+                  $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
     TaskEvent:
       oneOf:
-      - type: string
-        enum:
-        - deleted
-      - type: object
-        required:
-        - play_state
-        properties:
-          play_state:
-            type: object
-            required:
-            - current
-            - desired
-            - waiting_instances
-            - waiting_media
-            properties:
-              current:
-                $ref: '#/components/schemas/Timestamped_for_TaskPlayState'
-              desired:
-                $ref: '#/components/schemas/Timestamped_for_DesiredTaskPlayState'
-              waiting_instances:
-                type: array
-                items:
-                  $ref: '#/components/schemas/FixedInstanceId'
-                uniqueItems: true
-              waiting_media:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AppMediaObjectId'
-                uniqueItems: true
-        additionalProperties: false
-      - type: object
-        required:
-        - streaming_packet
-        properties:
-          streaming_packet:
-            type: object
-            required:
-            - packet
-            properties:
-              packet:
-                $ref: '#/components/schemas/StreamingPacket'
-        additionalProperties: false
+        - type: string
+          enum:
+            - deleted
+        - type: object
+          required:
+            - play_state
+          properties:
+            play_state:
+              type: object
+              required:
+                - current
+                - desired
+                - waiting_instances
+                - waiting_media
+              properties:
+                current:
+                  $ref: '#/components/schemas/Timestamped_for_TaskPlayState'
+                desired:
+                  $ref: '#/components/schemas/Timestamped_for_DesiredTaskPlayState'
+                waiting_instances:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/FixedInstanceId'
+                  uniqueItems: true
+                waiting_media:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/AppMediaObjectId'
+                  uniqueItems: true
+          additionalProperties: false
+        - type: object
+          required:
+            - streaming_packet
+          properties:
+            streaming_packet:
+              type: object
+              required:
+                - packet
+              properties:
+                packet:
+                  $ref: '#/components/schemas/StreamingPacket'
+          additionalProperties: false
     TaskId:
       title: TaskId
       type: string
     TaskPermissions:
       type: object
       required:
-      - audio
-      - media
-      - parameters
-      - structure
-      - transport
+        - audio
+        - media
+        - parameters
+        - structure
+        - transport
       properties:
         audio:
           type: boolean
@@ -3474,141 +3474,141 @@ components:
           type: boolean
     TaskPlayState:
       oneOf:
-      - type: string
-        enum:
-        - stopped
-      - type: object
-        required:
-        - preparing_to_play
-        properties:
-          preparing_to_play:
-            $ref: '#/components/schemas/RequestPlay'
-        additionalProperties: false
-      - type: object
-        required:
-        - preparing_to_render
-        properties:
-          preparing_to_render:
-            $ref: '#/components/schemas/RequestRender'
-        additionalProperties: false
-      - type: object
-        required:
-        - playing
-        properties:
-          playing:
-            $ref: '#/components/schemas/RequestPlay'
-        additionalProperties: false
-      - type: object
-        required:
-        - rendering
-        properties:
-          rendering:
-            $ref: '#/components/schemas/RequestRender'
-        additionalProperties: false
-      - type: object
-        required:
-        - stopping_play
-        properties:
-          stopping_play:
-            $ref: '#/components/schemas/PlayId'
-        additionalProperties: false
-      - type: object
-        required:
-        - stopping_render
-        properties:
-          stopping_render:
-            $ref: '#/components/schemas/RenderId'
-        additionalProperties: false
+        - type: string
+          enum:
+            - stopped
+        - type: object
+          required:
+            - preparing_to_play
+          properties:
+            preparing_to_play:
+              $ref: '#/components/schemas/RequestPlay'
+          additionalProperties: false
+        - type: object
+          required:
+            - preparing_to_render
+          properties:
+            preparing_to_render:
+              $ref: '#/components/schemas/RequestRender'
+          additionalProperties: false
+        - type: object
+          required:
+            - playing
+          properties:
+            playing:
+              $ref: '#/components/schemas/RequestPlay'
+          additionalProperties: false
+        - type: object
+          required:
+            - rendering
+          properties:
+            rendering:
+              $ref: '#/components/schemas/RequestRender'
+          additionalProperties: false
+        - type: object
+          required:
+            - stopping_play
+          properties:
+            stopping_play:
+              $ref: '#/components/schemas/PlayId'
+          additionalProperties: false
+        - type: object
+          required:
+            - stopping_render
+          properties:
+            stopping_render:
+              $ref: '#/components/schemas/RenderId'
+          additionalProperties: false
     TaskPlayStateSummary:
       type: string
       enum:
-      - preparing_to_play
-      - preparing_to_render
-      - playing
-      - rendering
-      - stopping_play
-      - stopping_render
-      - stopped
+        - preparing_to_play
+        - preparing_to_render
+        - playing
+        - rendering
+        - stopping_play
+        - stopping_render
+        - stopped
     TaskPlayStopped:
       title: TaskPlayStopped
       oneOf:
-      - type: object
-        required:
-        - stopped
-        properties:
-          stopped:
-            type: object
-            required:
-            - play_id
-            - task_id
-            properties:
-              play_id:
-                $ref: '#/components/schemas/PlayId'
-              task_id:
-                $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
+        - type: object
+          required:
+            - stopped
+          properties:
+            stopped:
+              type: object
+              required:
+                - play_id
+                - task_id
+              properties:
+                play_id:
+                  $ref: '#/components/schemas/PlayId'
+                task_id:
+                  $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
     TaskPlaying:
       title: TaskPlaying
       oneOf:
-      - type: object
-        required:
-        - playing
-        properties:
-          playing:
-            type: object
-            required:
-            - play_id
-            - task_id
-            properties:
-              play_id:
-                $ref: '#/components/schemas/PlayId'
-              task_id:
-                $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
+        - type: object
+          required:
+            - playing
+          properties:
+            playing:
+              type: object
+              required:
+                - play_id
+                - task_id
+              properties:
+                play_id:
+                  $ref: '#/components/schemas/PlayId'
+                task_id:
+                  $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
     TaskRenderCancelled:
       title: TaskRenderCancelled
       oneOf:
-      - type: object
-        required:
-        - cancelled
-        properties:
-          cancelled:
-            type: object
-            required:
-            - render_id
-            - task_id
-            properties:
-              render_id:
-                $ref: '#/components/schemas/RenderId'
-              task_id:
-                $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
+        - type: object
+          required:
+            - cancelled
+          properties:
+            cancelled:
+              type: object
+              required:
+                - render_id
+                - task_id
+              properties:
+                render_id:
+                  $ref: '#/components/schemas/RenderId'
+                task_id:
+                  $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
     TaskRendering:
       title: TaskRendering
       oneOf:
-      - type: object
-        required:
-        - rendering
-        properties:
-          rendering:
-            type: object
-            required:
-            - render_id
-            - task_id
-            properties:
-              render_id:
-                $ref: '#/components/schemas/RenderId'
-              task_id:
-                $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
+        - type: object
+          required:
+            - rendering
+          properties:
+            rendering:
+              type: object
+              required:
+                - render_id
+                - task_id
+              properties:
+                render_id:
+                  $ref: '#/components/schemas/RenderId'
+                task_id:
+                  $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
     TaskReservation:
       description: Timed resource reservations for the task (must contain all used resources)
       type: object
       required:
-      - fixed_instances
-      - from
-      - revision
-      - to
+        - fixed_instances
+        - from
+        - revision
+        - to
       properties:
         fixed_instances:
           description: Fixed instances reserved for the task
@@ -3633,7 +3633,7 @@ components:
       description: Information about access keys and permissions of a task
       type: object
       required:
-      - security
+        - security
       properties:
         revision:
           description: Revision number - starts at zero and is incremented at every change of task security
@@ -3649,46 +3649,46 @@ components:
     TaskSought:
       title: TaskSought
       oneOf:
-      - type: object
-        required:
-        - sought
-        properties:
-          sought:
-            type: object
-            required:
-            - play_id
-            - task_id
-            properties:
-              play_id:
-                $ref: '#/components/schemas/PlayId'
-              task_id:
-                $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
+        - type: object
+          required:
+            - sought
+          properties:
+            sought:
+              type: object
+              required:
+                - play_id
+                - task_id
+              properties:
+                play_id:
+                  $ref: '#/components/schemas/PlayId'
+                task_id:
+                  $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
     TaskSpec:
       description: Task specification
       type: object
       properties:
         connections:
           description: Connections between nodes
-          default: {}
+          default: { }
           type: object
           additionalProperties:
             $ref: '#/components/schemas/NodeConnection'
         dynamic:
           description: Dynamic instance nodes of the task
-          default: {}
+          default: { }
           type: object
           additionalProperties:
             $ref: '#/components/schemas/DynamicInstanceNode'
         fixed:
           description: Fixed instance nodes of the task
-          default: {}
+          default: { }
           type: object
           additionalProperties:
             $ref: '#/components/schemas/FixedInstanceNode'
         mixers:
           description: Mixer nodes of the task
-          default: {}
+          default: { }
           type: object
           additionalProperties:
             $ref: '#/components/schemas/MixerNode'
@@ -3700,7 +3700,7 @@ components:
           minimum: 0.0
         tracks:
           description: Track nodes of the task
-          default: {}
+          default: { }
           type: object
           additionalProperties:
             $ref: '#/components/schemas/TrackNode'
@@ -3708,19 +3708,19 @@ components:
       description: A summary of a task
       type: object
       required:
-      - play_state
-      - task_id
-      - waiting_for_instances
-      - waiting_for_media
+        - play_state
+        - task_id
+        - waiting_for_instances
+        - waiting_for_media
       properties:
         play_state:
           description: Current play sate
           allOf:
-          - $ref: '#/components/schemas/TaskPlayState'
+            - $ref: '#/components/schemas/TaskPlayState'
         task_id:
           description: Task Id
           allOf:
-          - $ref: '#/components/schemas/AppTaskId'
+            - $ref: '#/components/schemas/AppTaskId'
         waiting_for_instances:
           description: List of instances that are blocking play state change
           type: array
@@ -3742,58 +3742,58 @@ components:
       title: TaskUpdated
       description: Response to modifying a task on the domain
       oneOf:
-      - description: Updated normally
-        type: object
-        required:
-        - updated
-        properties:
-          updated:
-            type: object
-            required:
-            - revision
-            - task_id
-            properties:
-              revision:
-                description: New version to be used with `If-Matches` when submitting further modifications
-                type: integer
-                format: uint64
-                minimum: 0.0
-              task_id:
-                description: Task Id
-                allOf:
-                - $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
-      - description: Did not update because a newer revision was specified and update is optional
-        type: object
-        required:
-        - ignored
-        properties:
-          ignored:
-            type: object
-            required:
-            - revision
-            - task_id
-            properties:
-              revision:
-                description: Current version to be used with `If-Matches` when submitting further modifications
-                type: integer
-                format: uint64
-                minimum: 0.0
-              task_id:
-                description: Task Id
-                allOf:
-                - $ref: '#/components/schemas/AppTaskId'
-        additionalProperties: false
+        - description: Updated normally
+          type: object
+          required:
+            - updated
+          properties:
+            updated:
+              type: object
+              required:
+                - revision
+                - task_id
+              properties:
+                revision:
+                  description: New version to be used with `If-Matches` when submitting further modifications
+                  type: integer
+                  format: uint64
+                  minimum: 0.0
+                task_id:
+                  description: Task Id
+                  allOf:
+                    - $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
+        - description: Did not update because a newer revision was specified and update is optional
+          type: object
+          required:
+            - ignored
+          properties:
+            ignored:
+              type: object
+              required:
+                - revision
+                - task_id
+              properties:
+                revision:
+                  description: Current version to be used with `If-Matches` when submitting further modifications
+                  type: integer
+                  format: uint64
+                  minimum: 0.0
+                task_id:
+                  description: Task Id
+                  allOf:
+                    - $ref: '#/components/schemas/AppTaskId'
+          additionalProperties: false
     TaskWithStatusAndSpec:
       title: TaskWithStatusAndSpec
       description: A more complete information about a task
       type: object
       required:
-      - instances
-      - media
-      - play_state
-      - spec
-      - task_id
+        - instances
+        - media
+        - play_state
+        - spec
+        - task_id
       properties:
         instances:
           description: State of attatched fixed instances
@@ -3808,20 +3808,20 @@ components:
         play_state:
           description: Current play state
           allOf:
-          - $ref: '#/components/schemas/TaskPlayState'
+            - $ref: '#/components/schemas/TaskPlayState'
         spec:
           description: The current specification of the task
           allOf:
-          - $ref: '#/components/schemas/TaskSpec'
+            - $ref: '#/components/schemas/TaskSpec'
         task_id:
           description: Task Id
           allOf:
-          - $ref: '#/components/schemas/AppTaskId'
+            - $ref: '#/components/schemas/AppTaskId'
     TimeRange:
       type: object
       required:
-      - from
-      - to
+        - from
+        - to
       properties:
         from:
           type: string
@@ -3832,8 +3832,8 @@ components:
     TimeSegment:
       type: object
       required:
-      - length
-      - start
+        - length
+        - start
       properties:
         length:
           type: number
@@ -3844,120 +3844,120 @@ components:
     Timestamped_for_Boolean:
       type: array
       items:
-      - type: string
-        format: date-time
-      - type: boolean
+        - type: string
+          format: date-time
+        - type: boolean
       maxItems: 2
       minItems: 2
     Timestamped_for_DesiredInstancePlayState:
       type: array
       items:
-      - type: string
-        format: date-time
-      - $ref: '#/components/schemas/DesiredInstancePlayState'
+        - type: string
+          format: date-time
+        - $ref: '#/components/schemas/DesiredInstancePlayState'
       maxItems: 2
       minItems: 2
     Timestamped_for_DesiredInstancePowerState:
       type: array
       items:
-      - type: string
-        format: date-time
-      - $ref: '#/components/schemas/DesiredInstancePowerState'
+        - type: string
+          format: date-time
+        - $ref: '#/components/schemas/DesiredInstancePowerState'
       maxItems: 2
       minItems: 2
     Timestamped_for_DesiredTaskPlayState:
       type: array
       items:
-      - type: string
-        format: date-time
-      - $ref: '#/components/schemas/DesiredTaskPlayState'
+        - type: string
+          format: date-time
+        - $ref: '#/components/schemas/DesiredTaskPlayState'
       maxItems: 2
       minItems: 2
     Timestamped_for_InstancePlayState:
       type: array
       items:
-      - type: string
-        format: date-time
-      - $ref: '#/components/schemas/InstancePlayState'
+        - type: string
+          format: date-time
+        - $ref: '#/components/schemas/InstancePlayState'
       maxItems: 2
       minItems: 2
     Timestamped_for_InstancePowerState:
       type: array
       items:
-      - type: string
-        format: date-time
-      - $ref: '#/components/schemas/InstancePowerState'
+        - type: string
+          format: date-time
+        - $ref: '#/components/schemas/InstancePowerState'
       maxItems: 2
       minItems: 2
     Timestamped_for_Nullable_double:
       type: array
       items:
-      - type: string
-        format: date-time
-      - type:
-        - number
-        - 'null'
-        format: double
+        - type: string
+          format: date-time
+        - type:
+            - number
+            - 'null'
+          format: double
       maxItems: 2
       minItems: 2
     Timestamped_for_TaskPlayState:
       type: array
       items:
-      - type: string
-        format: date-time
-      - $ref: '#/components/schemas/TaskPlayState'
+        - type: string
+          format: date-time
+        - $ref: '#/components/schemas/TaskPlayState'
       maxItems: 2
       minItems: 2
     TrackMedia:
       description: Media item specification
       type: object
       required:
-      - channels
-      - format
-      - media_segment
-      - object_id
-      - timeline_segment
+        - channels
+        - format
+        - media_segment
+        - object_id
+        - timeline_segment
       properties:
         channels:
           description: Number of channels
           allOf:
-          - $ref: '#/components/schemas/MediaChannels'
+            - $ref: '#/components/schemas/MediaChannels'
         format:
           description: Media format
           allOf:
-          - $ref: '#/components/schemas/TrackMediaFormat'
+            - $ref: '#/components/schemas/TrackMediaFormat'
         media_segment:
           description: Subset of media that is used
           allOf:
-          - $ref: '#/components/schemas/TimeSegment'
+            - $ref: '#/components/schemas/TimeSegment'
         object_id:
           description: Source media object id
           allOf:
-          - $ref: '#/components/schemas/MediaObjectId'
+            - $ref: '#/components/schemas/MediaObjectId'
         timeline_segment:
           description: Where to place the media in the task timeline
           allOf:
-          - $ref: '#/components/schemas/TimeSegment'
+            - $ref: '#/components/schemas/TimeSegment'
     TrackMediaFormat:
       type: string
       enum:
-      - wave
-      - mp3
-      - flac
-      - wavpack
+        - wave
+        - mp3
+        - flac
+        - wavpack
     TrackMediaId:
       type: string
     TrackNode:
       description: Track node specification
       type: object
       required:
-      - channels
-      - media
+        - channels
+        - media
       properties:
         channels:
           description: Number of channels
           allOf:
-          - $ref: '#/components/schemas/MediaChannels'
+            - $ref: '#/components/schemas/MediaChannels'
         media:
           description: Media items present on the track
           type: object
@@ -3970,17 +3970,17 @@ components:
       properties:
         channels:
           anyOf:
-          - $ref: '#/components/schemas/MediaChannels'
-          - type: 'null'
+            - $ref: '#/components/schemas/MediaChannels'
+            - type: 'null'
         media_segment:
           anyOf:
-          - $ref: '#/components/schemas/TimeSegment'
-          - type: 'null'
+            - $ref: '#/components/schemas/TimeSegment'
+            - type: 'null'
         object_id:
           anyOf:
-          - $ref: '#/components/schemas/MediaObjectId'
-          - type: 'null'
+            - $ref: '#/components/schemas/MediaObjectId'
+            - type: 'null'
         timeline_segment:
           anyOf:
-          - $ref: '#/components/schemas/TimeSegment'
-          - type: 'null'
+            - $ref: '#/components/schemas/TimeSegment'
+            - type: 'null'


### PR DESCRIPTION
Observability (logging, tracing, metrics) require a lot of setup to get right. We've done a pretty good job in Domain Server. Extract the o11y code from the Domain Server put it in a separate project (audiocloud-tracing) and put in lib with other utility / shared code.